### PR TITLE
18.3 testing

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -1252,8 +1252,8 @@ channel_tcpwinsz(struct ssh *ssh)
 	 * the size of the advertised window. Now this means that any HPN to non-HPN
 	 * connection will be window limited but thats okay. This bug shows up when
 	 * sending data to an hpn */
-	if ((ssh->compat & SSH_RESTRICT_WINDOW) && (tcpwinsz > NON_HPN_WINDOW_MAX))
-		tcpwinsz = NON_HPN_WINDOW_MAX;
+	//if ((ssh->compat & SSH_RESTRICT_WINDOW) && (tcpwinsz > NON_HPN_WINDOW_MAX))
+	//	tcpwinsz = NON_HPN_WINDOW_MAX;
 	return (tcpwinsz);
 }
 
@@ -2368,6 +2368,10 @@ channel_check_window(struct ssh *ssh, Channel *c)
 	    c->local_consumed > 0) {
 		u_int addition = 0;
 		u_int32_t tcpwinsz = channel_tcpwinsz(ssh);
+		if ((ssh->compat & SSH_RESTRICT_WINDOW) &&
+		    (tcpwinsz > NON_HPN_WINDOW_MAX))
+			tcpwinsz = NON_HPN_WINDOW_MAX;
+		
 		/* adjust max window size if we are in a dynamic environment
 		 * and the tcp receive buffer is larger than the ssh window */
 		if (c->dynamic_window && (tcpwinsz > c->local_window_max)) {
@@ -2386,13 +2390,10 @@ channel_check_window(struct ssh *ssh, Channel *c)
 				addition = tcpwinsz - c->local_window_max;
 			}
 			c->local_window_max += addition;
-			sshbuf_set_window_max(c->output, c->local_window_max);
-			sshbuf_set_window_max(c->input, c->local_window_max);
+			//sshbuf_set_window_max(c->output, c->local_window_max);
+			//sshbuf_set_window_max(c->input, c->local_window_max);
 			debug("Channel %d: Window growth to %d by %d bytes",c->self,
 			      c->local_window_max, addition);
-			//if ((ssh->compat & SSH_RESTRICT_WINDOW) &&
-			//    (addition > NON_HPN_WINDOW_MAX))
-			//	addition = NON_HPN_WINDOW_MAX;
 		}
 		if (!c->have_remote_id)
 			fatal_f("channel %d: no remote id", c->self);

--- a/channels.c
+++ b/channels.c
@@ -104,6 +104,11 @@
 /* Maximum number of fake X11 displays to try. */
 #define MAX_DISPLAYS  1000
 
+/* in version of OpenSSH later than 8.8 if we advertise a window
+ * 16MB or larger is causes a pathological behaviour that reduces
+ * throughput. This is not a great solution. */
+#define NON_HPN_WINDOW_MAX (15 * 1024 * 1024)
+
 /* Per-channel callback for pre/post IO actions */
 typedef void chan_fn(struct ssh *, Channel *c);
 
@@ -1243,8 +1248,13 @@ channel_tcpwinsz(struct ssh *ssh)
 	/* return no more than SSHBUF_SIZE_MAX (currently 256MB) */
 	if ((ret == 0) && tcpwinsz > SSHBUF_SIZE_MAX)
 		tcpwinsz = SSHBUF_SIZE_MAX;
-
-	return tcpwinsz;
+	/* if the remote side is OpenSSH after version 8.8 we need to restrict
+	 * the size of the advertised window. Now this means that any HPN to non-HPN
+	 * connection will be window limited but thats okay. This bug shows up when
+	 * sending data to an hpn */
+	if ((ssh->compat & SSH_RESTRICT_WINDOW) && (tcpwinsz > NON_HPN_WINDOW_MAX))
+		tcpwinsz = NON_HPN_WINDOW_MAX;
+	return (tcpwinsz);
 }
 
 static void
@@ -2380,6 +2390,9 @@ channel_check_window(struct ssh *ssh, Channel *c)
 			sshbuf_set_window_max(c->input, c->local_window_max);
 			debug("Channel %d: Window growth to %d by %d bytes",c->self,
 			      c->local_window_max, addition);
+			//if ((ssh->compat & SSH_RESTRICT_WINDOW) &&
+			//    (addition > NON_HPN_WINDOW_MAX))
+			//	addition = NON_HPN_WINDOW_MAX;
 		}
 		if (!c->have_remote_id)
 			fatal_f("channel %d: no remote id", c->self);
@@ -2390,6 +2403,8 @@ channel_check_window(struct ssh *ssh, Channel *c)
 		    (r = sshpkt_send(ssh)) != 0) {
 			fatal_fr(r, "channel %i", c->self);
 		}
+		debug2("channel %d: window %d sent adjust %d", c->self,
+		       c->local_window, c->local_consumed + addition);
 		c->local_window += c->local_consumed + addition;
 		c->local_consumed = 0;
 	}

--- a/clientloop.c
+++ b/clientloop.c
@@ -2990,7 +2990,7 @@ client_session2_setup(struct ssh *ssh, int id, int want_tty, int want_subsystem,
 		 * binaries installed. In that case we need to rewrite any
 		 * scp commands to look for hpnscp instead.
 		 */
-		if (ssh->compat & SSH_HPNSSH) {
+		if (ssh->compat & SSH_HPNSSH_PREFIX) {
 			char *new_cmd;
 			new_cmd = malloc(len+4);
 			/* read the existing command into a temp buffer */

--- a/compat.c
+++ b/compat.c
@@ -124,9 +124,11 @@ compat_banner(struct ssh *ssh, const char *version)
 		{ NULL,			0 }
 	};
 
+	debug ("------------------------ VERSION IS %s", version);
 	/* process table, return first match */
 	ssh->compat = 0;
 	for (i = 0; check[i].pat; i++) {
+		debug_f("PATTERN IS %d for %s\n", i, check[i].pat);
 		if (match_pattern_list(version, check[i].pat, 0) == 1) {
 			debug_f("match: %s pat %s compat 0x%08x",
 			    version, check[i].pat, check[i].bugs);
@@ -134,26 +136,32 @@ compat_banner(struct ssh *ssh, const char *version)
 			/* Check to see if the remote side is OpenSSH and not HPN */
 			/* TODO: See if we can work this into the new method for bug checks */
 			if (strstr(version, "OpenSSH") != NULL) {
-				if (strstr(version, "hpn") == NULL) {
-					ssh->compat |= SSH_BUG_LARGEWINDOW;
-					debug("Remote is NOT HPN enabled");
-				} else {
-					/* this checks to see if the remote
-					 * version string indicates that we
-					 * have access to hpn prefixed binaries
-					 * You'll need to change this to include
-					 * new major version numbers. Which is
-					 * why we should figure out how to make
-					 * the match pattern list work
-					 */
-					if ((strstr(version, "hpn16") != NULL) ||
-					    (strstr(version, "hpn17") != NULL))
-						ssh->compat |= SSH_HPNSSH;
-					debug("Remote is HPN Enabled");
+				if (strstr(version, "hpn")) {
+					ssh->compat |= SSH_HPNSSH;
+					debug("Remote is HPN enabled");
+				}
+				/* this checks to see if the remote
+				 * version string indicates that we
+				 * have access to hpn prefixed binaries
+				 * You'll need to change this to include
+				 * new major version numbers. Which is
+				 * why we should figure out how to make
+				 * the match pattern list work
+				 */
+				if ((strstr(version, "hpn16") != NULL) ||
+				    (strstr(version, "hpn17") != NULL) ||
+				    (strstr(version, "hpn18") != NULL)) {
+					ssh->compat |= SSH_HPNSSH_PREFIX;
+					debug("Remote uses HPNSSH prefixes.");
+					break;
+				}
+				if ((strstr(version, "OpenSSH_8.9") != NULL) ||
+				    (strstr(version, "OpenSSH_9") != NULL)) {
+					ssh->compat |= SSH_RESTRICT_WINDOW;
+					debug("Restricting adverstised window size.");
 				}
 			}
 			debug("ssh->compat is %u", ssh->compat);
-			return;
 		}
 	}
 	debug_f("no match: %s", version);

--- a/compat.c
+++ b/compat.c
@@ -124,11 +124,9 @@ compat_banner(struct ssh *ssh, const char *version)
 		{ NULL,			0 }
 	};
 
-	debug ("------------------------ VERSION IS %s", version);
 	/* process table, return first match */
 	ssh->compat = 0;
 	for (i = 0; check[i].pat; i++) {
-		debug_f("PATTERN IS %d for %s\n", i, check[i].pat);
 		if (match_pattern_list(version, check[i].pat, 0) == 1) {
 			debug_f("match: %s pat %s compat 0x%08x",
 			    version, check[i].pat, check[i].bugs);
@@ -155,6 +153,7 @@ compat_banner(struct ssh *ssh, const char *version)
 					debug("Remote uses HPNSSH prefixes.");
 					break;
 				}
+				/* if it's openssh and not hpn */
 				if ((strstr(version, "OpenSSH_8.9") != NULL) ||
 				    (strstr(version, "OpenSSH_9") != NULL)) {
 					ssh->compat |= SSH_RESTRICT_WINDOW;
@@ -162,6 +161,7 @@ compat_banner(struct ssh *ssh, const char *version)
 				}
 			}
 			debug("ssh->compat is %u", ssh->compat);
+			return;
 		}
 	}
 	debug_f("no match: %s", version);

--- a/compat.h
+++ b/compat.h
@@ -46,18 +46,18 @@
 /* #define unused		0x00010000 */
 /* #define unused		0x00020000 */
 /* #define unused		0x00040000 */
-/* #define unused		0x00100000 */
+#define SSH_HPNSSH		0x00100000 /* basically a notice that this is HPN aware */
 #define SSH_BUG_EXTEOF		0x00200000
 #define SSH_BUG_PROBE		0x00400000
-/* #define unused		0x00800000 */
+#define SSH_RESTRICT_WINDOW	0x00800000 /* restrict adverstised window to OpenSSH clients */
 #define SSH_OLD_FORWARD_ADDR	0x01000000
-#define SSH_HPNSSH		0x02000000 /* indicates that we have hpn prefixes binaries */
+#define SSH_HPNSSH_PREFIX	0x02000000 /* indicates that we have hpn prefixes binaries */
 #define SSH_NEW_OPENSSH		0x04000000
 #define SSH_BUG_DYNAMIC_RPORT	0x08000000
 #define SSH_BUG_CURVE25519PAD	0x10000000
 #define SSH_BUG_HOSTKEYS	0x20000000
 #define SSH_BUG_DHGEX_LARGE	0x40000000
-#define SSH_BUG_LARGEWINDOW	0x80000000 /* basically a notice that this is HPN aware */
+/* #define unused	        0x80000000 */
 
 struct ssh;
 

--- a/kex.c
+++ b/kex.c
@@ -1753,8 +1753,8 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 		debug("Non-HPN to HPN Connection.");
 
 	if(ssh->compat & SSH_RESTRICT_WINDOW)
-		debug ("---------------------- RESTRICT");
-	
+		debug ("Window size restricted.");
+
 	mismatch = 0;
 	switch (remote_major) {
 	case 2:

--- a/kex.c
+++ b/kex.c
@@ -1600,7 +1600,7 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 	if (version_addendum != NULL && *version_addendum == '\0')
 		version_addendum = NULL;
 	if ((r = sshbuf_putf(our_version, "SSH-%d.%d-%s%s%s\r\n",
-	    PROTOCOL_MAJOR_2, PROTOCOL_MINOR_2, SSH_VERSION,
+	    PROTOCOL_MAJOR_2, PROTOCOL_MINOR_2, SSH_RELEASE,
 	    version_addendum == NULL ? "" : " ",
 	    version_addendum == NULL ? "" : version_addendum)) != 0) {
 		oerrno = errno;

--- a/kex.c
+++ b/kex.c
@@ -1747,7 +1747,14 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 	debug("Remote protocol version %d.%d, remote software version %.100s",
 	    remote_major, remote_minor, remote_version);
 	compat_banner(ssh, remote_version);
+	if (ssh->compat & SSH_HPNSSH)
+		debug("HPN to HPN Connection.");
+	else
+		debug("Non-HPN to HPN Connection.");
 
+	if(ssh->compat & SSH_RESTRICT_WINDOW)
+		debug ("---------------------- RESTRICT");
+	
 	mismatch = 0;
 	switch (remote_major) {
 	case 2:

--- a/ssh.c
+++ b/ssh.c
@@ -2194,14 +2194,6 @@ ssh_session2_setup(struct ssh *ssh, int id, int success, void *arg)
 static void
 hpn_options_init(struct ssh *ssh)
 {
-	if (ssh->compat & SSH_HPNSSH)
-		debug("HPN to HPN Connection.");
-	else
-		debug("Non-HPN to HPN Connection.");
-
-	if(ssh->compat & SSH_RESTRICT_WINDOW)
-		debug ("---------------------- RESTRICT");
-
 	channel_set_hpn_disabled(options.hpn_disabled);
 	debug_f("HPN disabled: %d", options.hpn_disabled);
 }

--- a/ssh.c
+++ b/ssh.c
@@ -1881,7 +1881,6 @@ fork_postauth(struct ssh *ssh)
 		fatal("daemon() failed: %.200s", strerror(errno));
 	if (stdfd_devnull(1, 1, !(log_is_on_stderr() && debug_flag)) == -1)
 		error_f("stdfd_devnull failed");
-
 	/* we do the cipher switch here in the event that the client
 	   is forking or has a delayed fork */
 	cipher_switch(ssh);
@@ -2195,6 +2194,14 @@ ssh_session2_setup(struct ssh *ssh, int id, int success, void *arg)
 static void
 hpn_options_init(struct ssh *ssh)
 {
+	if (ssh->compat & SSH_HPNSSH)
+		debug("HPN to HPN Connection.");
+	else
+		debug("Non-HPN to HPN Connection.");
+
+	if(ssh->compat & SSH_RESTRICT_WINDOW)
+		debug ("---------------------- RESTRICT");
+
 	channel_set_hpn_disabled(options.hpn_disabled);
 	debug_f("HPN disabled: %d", options.hpn_disabled);
 }

--- a/sshbuf.c
+++ b/sshbuf.c
@@ -371,7 +371,7 @@ sshbuf_check_reserve(const struct sshbuf *buf, size_t len)
 void
 sshbuf_set_window_max(struct sshbuf *buf, size_t len)
 {
-	buf->window_max = len;
+	//buf->window_max = len;
 }
 
 int

--- a/sshbuf.c
+++ b/sshbuf.c
@@ -371,7 +371,7 @@ sshbuf_check_reserve(const struct sshbuf *buf, size_t len)
 void
 sshbuf_set_window_max(struct sshbuf *buf, size_t len)
 {
-	//buf->window_max = len;
+	buf->window_max = len;
 }
 
 int


### PR DESCRIPTION
This is a fix for the poor performance for when OpenSSH clients are sending to HPN-SSH installs. The cause of this problem is still under investigation but is related, in some way, to the channel input buffer hitting a limit of 16MB. This value corresponds to the advertised application layer receive window sent by the HPN install. The fix is to limit the advertised window to 15MB. This does impact performance - which is annoying. More work will hopefully uncover a better long term fix. 