### PR TITLE
Temporary bug fix for 128bit xors in AES-CTR-MT. Not sure of the

### DIFF
--- a/cipher-ctr-mt-functions.c
+++ b/cipher-ctr-mt-functions.c
@@ -608,9 +608,15 @@ int aes_mt_do_cipher(void *vevp_ctx,
 		 * may need to do it in 8 or 4 bytes chunks
 		 * worst case is doing it as a loop */
 #ifdef CIPHER_INT128_OK
-		if ((align & 0xf) == 0) {
-			destp.u128[0] = srcp.u128[0] ^ bufp.u128[0];
-		} else
+		/* with GCC 13 we have having consistent seg faults
+		 * in this section of code. Since this is a critical
+		 * code path we are removing this until we have a solution
+		 * in place -cjr 02/22/24
+		 * TODO: FIX THIS
+		 */
+		/* if ((align & 0xf) == 0) { */
+		/* 	destp.u128[0] = srcp.u128[0] ^ bufp.u128[0]; */
+		/* } else */
 #endif
 		/* 64 bits */
 		if ((align & 0x7) == 0) {

--- a/cipher-ctr-mt.c
+++ b/cipher-ctr-mt.c
@@ -461,9 +461,15 @@ ssh_aes_ctr(EVP_CIPHER_CTX *ctx, u_char *dest, const u_char *src,
 		 * may need to do it in 8 or 4 bytes chunks
 		 * worst case is doing it as a loop */
 #ifdef CIPHER_INT128_OK
-		if ((align & 0xf) == 0) {
-			destp.u128[0] = srcp.u128[0] ^ bufp.u128[0];
-		} else
+		/* with GCC 13 we have having consistent seg faults
+		 * in this section of code. Since this is a critical
+		 * code path we are removing this until we have a solution
+		 * in place -cjr 02/22/24
+		 * TODO: FIX THIS
+		 */
+		/* if ((align & 0xf) == 0) { */
+		/* 	destp.u128[0] = srcp.u128[0] ^ bufp.u128[0]; */
+		/* } else */
 #endif
 		/* 64 bits */
 		if ((align & 0x7) == 0) {


### PR DESCRIPTION
Temporary bug fix for 128bit xors in AES-CTR-MT. Not sure of the cause but it's happening under GCC13 and not GCC12 or GCC11 so we are thinking something has changed there. This shouldn't impact performance all that much.