### PR TITLE
Dev minor

### DIFF
--- a/.github/configs
+++ b/.github/configs
@@ -164,6 +164,11 @@ case "$config" in
     libressl-*)
 	LIBCRYPTOFLAGS="--with-ssl-dir=/opt/libressl --with-rpath=-Wl,-rpath,"
 	;;
+    putty-*)
+	CONFIGFLAGS="--with-plink=/usr/local/bin/plink --with-puttygen=/usr/local/bin/puttygen"
+	# We don't need to rerun the regular tests, just the interop ones.
+	TEST_TARGET=interop-tests
+	;;
     openssl-*)
 	LIBCRYPTOFLAGS="--with-ssl-dir=/opt/openssl --with-rpath=-Wl,-rpath,"
 	# OpenSSL 1.1.1 specifically has a bug in its RNG that breaks reexec
@@ -277,20 +282,22 @@ case "${TARGET_HOST}" in
 	;;
     minix3)
 	CONFIGFLAGS="${CONFIGFLAGS} --disable-security-key"
+	# Unix domain sockets don't work quite like we expect, so also
+	# disable FD passing (and thus multiplexing).
+	CONFIGFLAGS="${CONFIGFLAGS} --disable-fd-passing"
 	LIBCRYPTOFLAGS="--without-openssl"
+
 	# Minix does not have a loopback interface so we have to skip any
 	# test that relies on one.
 	# Also, Minix seems to be very limited in the number of select()
 	# calls that can be operating concurrently, so prune additional tests for that.
 	T="addrmatch agent-restrict brokenkeys cfgmatch cfgmatchlisten cfgparse
-	    connect connect-uri exit-status forwarding hostkey-agent
-	    key-options keyscan knownhosts-command login-timeout
+	    connect connect-uri dynamic-forward exit-status forwarding
+	    forward-control
+	    hostkey-agent key-options keyscan knownhosts-command login-timeout
 	    reconfigure reexec rekey scp scp-uri scp3 sftp sftp-badcmds
 	    sftp-batch sftp-cmds sftp-glob sftp-perm sftp-uri stderr-data
 	    transfer"
-	# Unix domain sockets don't work quite like we expect, so also skip any tests
-	# that use multiplexing.
-	T="$T connection-timeout dynamic-forward forward-control multiplex"
 	SKIP_LTESTS="$(echo $T)"
 	TEST_TARGET=t-exec
 	SUDO=""
@@ -328,6 +335,10 @@ case "$host" in
 	# modern versions don't ship with libcrypto.
 	LIBCRYPTOFLAGS="--without-openssl"
 	TEST_TARGET=t-exec
+
+	# On some OS X runners we can't write to /var/empty.
+	CONFIGFLAGS="${CONFIGFLAGS} --with-privsep-path=/usr/local/empty"
+
 	case "$host" in
 	*-darwin22.*)
 		# sudo -S nobody doesn't work on macos 13 for some reason.

--- a/.github/setup_ci.sh
+++ b/.github/setup_ci.sh
@@ -143,6 +143,10 @@ for TARGET in $TARGETS; do
         INSTALL_BORINGSSL=1
         PACKAGES="${PACKAGES} cmake ninja-build"
        ;;
+    putty-*)
+	INSTALL_PUTTY=$(echo "${TARGET}" | cut -f2 -d-)
+	PACKAGES="${PACKAGES} cmake"
+	;;
     valgrind*)
        PACKAGES="$PACKAGES valgrind"
        ;;
@@ -249,4 +253,26 @@ if [ ! -z "${INSTALL_ZLIB}" ]; then
     (cd ${HOME} && git clone https://github.com/madler/zlib.git &&
      cd ${HOME}/zlib && ./configure && make &&
      sudo make install prefix=/opt/zlib)
+fi
+
+if [ ! -z "${INSTALL_PUTTY}" ]; then
+    ver="${INSTALL_PUTTY}"
+    case "${INSTALL_PUTTY}" in
+    snapshot)
+	tarball=putty.tar.gz
+	(cd /tmp && wget https://tartarus.org/~simon/putty-snapshots/${tarball})
+	;;
+    *)
+	tarball=putty-${ver}.tar.gz
+	(cd /tmp && wget https://the.earth.li/~sgtatham/putty/${ver}/${tarball})
+	;;
+    esac
+    (cd ${HOME} && tar xfz /tmp/${tarball} && cd putty-*
+     if [ -f CMakeLists.txt ]; then
+	cmake . && cmake --build . && sudo cmake --build . --target install
+     else
+	./configure && make && sudo make install
+     fi
+    )
+    /usr/local/bin/plink -V
 fi

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,8 @@ jobs:
 #          - { target: ubuntu-20.04, config: valgrind-5 }
           - { target: ubuntu-20.04, config: valgrind-6 }
           - { target: ubuntu-20.04, config: valgrind-7 }
-          - { target: ubuntu-20.04, config: c89 }
+# binn.c no longer works with c89 so remove this test.
+#          - { target: ubuntu-20.04, config: c89 }
           - { target: ubuntu-20.04, config: clang-6.0 }
           - { target: ubuntu-20.04, config: clang-8 }
           - { target: ubuntu-20.04, config: clang-9 }

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -51,20 +51,32 @@ jobs:
 #         - { target: ubuntu-20.04, config: musl }
           - { target: ubuntu-latest, config: libressl-master }
           - { target: ubuntu-latest, config: libressl-3.7.2 }
-          - { target: ubuntu-latest, config: libressl-3.8.2 }
+          - { target: ubuntu-latest, config: libressl-3.8.3 }
+          - { target: ubuntu-latest, config: libressl-3.9.0 }
           - { target: ubuntu-latest, config: openssl-master }
           - { target: ubuntu-latest, config: openssl-noec }
           - { target: ubuntu-latest, config: openssl-1.1.1 }
           - { target: ubuntu-latest, config: openssl-1.1.1t }
           - { target: ubuntu-latest, config: openssl-1.1.1w }
           - { target: ubuntu-latest, config: openssl-3.0.0 }
-          - { target: ubuntu-latest, config: openssl-3.0.12 }
+          - { target: ubuntu-latest, config: openssl-3.0.13 }
           - { target: ubuntu-latest, config: openssl-3.1.0 }
-          - { target: ubuntu-latest, config: openssl-3.1.4 }
-          - { target: ubuntu-latest, config: openssl-3.2.0 }
+          - { target: ubuntu-latest, config: openssl-3.1.5 }
+          - { target: ubuntu-latest, config: openssl-3.2.1 }
           - { target: ubuntu-latest, config: openssl-1.1.1_stable }
           - { target: ubuntu-latest, config: openssl-3.0 }  # stable branch
           - { target: ubuntu-latest, config: openssl-3.2 }  # stable branch
+          - { target: ubuntu-latest, config: putty-0.71 }
+          - { target: ubuntu-latest, config: putty-0.72 }
+          - { target: ubuntu-latest, config: putty-0.73 }
+          - { target: ubuntu-latest, config: putty-0.74 }
+          - { target: ubuntu-latest, config: putty-0.75 }
+          - { target: ubuntu-latest, config: putty-0.76 }
+          - { target: ubuntu-latest, config: putty-0.77 }
+          - { target: ubuntu-latest, config: putty-0.78 }
+          - { target: ubuntu-latest, config: putty-0.79 }
+          - { target: ubuntu-latest, config: putty-0.80 }
+          - { target: ubuntu-latest, config: putty-snapshot }
           - { target: ubuntu-latest, config: zlib-develop }
           - { target: ubuntu-22.04, config: pam }
           - { target: ubuntu-22.04, config: krb5 }

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -73,6 +73,7 @@ jobs:
           - { target: fbsd14, config: pam, host: libvirt }
           - { target: nbsd8,  config: pam, host: libvirt }
           - { target: nbsd9,  config: pam, host: libvirt }
+          - { target: nbsd10, config: pam, host: libvirt }
           # VMs with persistent disks that have their own runner.
           - { target: win10, config: default, host: win10 }
           - { target: win10, config: cygwin-release, host: win10 }

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ survey.sh
 **/*.so
 **/*.out
 **/*.a
+**/*.un~
+**/.*.swp
 autom4te.cache/
 !regress/misc/fuzz-harness/Makefile
 !regress/unittests/sshsig/Makefile

--- a/.skipped-commit-ids
+++ b/.skipped-commit-ids
@@ -1,3 +1,4 @@
+509bb19bb9762a4b3b589af98bac2e730541b6d4	clean sshd random relinking kit
 5317f294d63a876bfc861e19773b1575f96f027d	remove libssh from makefiles
 a337e886a49f96701ccbc4832bed086a68abfa85	Makefile changes
 f2c9feb26963615c4fece921906cf72e248b61ee	more Makefile
@@ -27,6 +28,7 @@ cc12a9029833d222043aecd252d654965c351a69	moduli-gen Makefile
 f9a0726d957cf10692a231996a1f34e7f9cdfeb0	moduli update
 1e0a2692b7e20b126dda60bf04999d1d30d959d8	sshd relinking makefile changes
 e1dc11143f83082e3154d6094f9136d0dc2637ad	more relinking makefile tweaks
+5a636f6ca7f25bfe775df4952f7aac90a7fcbbee	moduli update
 
 Old upstream tree:
 

--- a/PROTOCOL
+++ b/PROTOCOL
@@ -137,12 +137,12 @@ than as a named global or channel request to allow pings with very
 short packet lengths, which would not be possible with other
 approaches.
 
-1.9 transport: strict key exchange extension
+1.10 transport: strict key exchange extension
 
 OpenSSH supports a number of transport-layer hardening measures under
 a "strict KEX" feature. This feature is signalled similarly to the
 RFC8308 ext-info feature: by including a additional algorithm in the
-initiial SSH2_MSG_KEXINIT kex_algorithms field. The client may append
+initial SSH2_MSG_KEXINIT kex_algorithms field. The client may append
 "kex-strict-c-v00@openssh.com" to its kex_algorithms and the server
 may append "kex-strict-s-v00@openssh.com". These pseudo-algorithms
 are only valid in the initial SSH2_MSG_KEXINIT and MUST be ignored
@@ -150,20 +150,21 @@ if they are present in subsequent SSH2_MSG_KEXINIT packets.
 
 When an endpoint that supports this extension observes this algorithm
 name in a peer's KEXINIT packet, it MUST make the following changes to
-the the protocol:
+the protocol:
 
-a) During initial KEX, terminate the connection if any unexpected or
-   out-of-sequence packet is received. This includes terminating the
-   connection if the first packet received is not SSH2_MSG_KEXINIT.
-   Unexpected packets for the purpose of strict KEX include messages
-   that are otherwise valid at any time during the connection such as
-   SSH2_MSG_DEBUG and SSH2_MSG_IGNORE.
+a) During initial KEX, terminate the connection if out-of-sequence
+   packet or any message that is not strictly required by KEX is
+   received. This includes terminating the connection if the first
+   packet received is not SSH2_MSG_KEXINIT. Unexpected packets for
+   the purpose of strict KEX include messages that are otherwise
+   valid at any time during the connection such as SSH2_MSG_DEBUG,
+   SSH2_MSG_IGNORE or SSH2_MSG_UNIMPLEMENTED.
 b) After sending or receiving a SSH2_MSG_NEWKEYS message, reset the
    packet sequence number to zero. This behaviour persists for the
    duration of the connection (i.e. not just the first
    SSH2_MSG_NEWKEYS).
 
-1.10 transport: SSH2_MSG_EXT_INFO during user authentication
+1.11 transport: SSH2_MSG_EXT_INFO during user authentication
 
 This protocol extension allows the SSH2_MSG_EXT_INFO to be sent
 during user authentication. RFC8308 does allow a second
@@ -735,6 +736,7 @@ identifiers:
 The server will reply with a SSH_FXP_EXTENDED_REPLY:
 
 	byte		SSH_FXP_EXTENDED_REPLY
+	uint32		id
 	string		usernames
 	string		groupnames
 
@@ -790,4 +792,4 @@ master instance and later clients.
 OpenSSH extends the usual agent protocol. These changes are documented
 in the PROTOCOL.agent file.
 
-$OpenBSD: PROTOCOL,v 1.51 2023/12/18 14:45:49 djm Exp $
+$OpenBSD: PROTOCOL,v 1.55 2024/01/08 05:05:15 djm Exp $

--- a/PROTOCOL.agent
+++ b/PROTOCOL.agent
@@ -91,7 +91,7 @@ with private keys as they are loaded from a PKCS#11 token.
 	bool		certs_only
 	string		certsblob
 
-Where "certsblob" constists of one or more certificates encoded as public
+Where "certsblob" consists of one or more certificates encoded as public
 key blobs:
 
 	string[]	certificates
@@ -112,4 +112,4 @@ A SSH_AGENTC_ADD_SMARTCARD_KEY_CONSTRAINED will return SSH_AGENT_SUCCESS
 if any key (plain private or certificate) was successfully loaded, or
 SSH_AGENT_FAILURE if no key was loaded.
 
-$OpenBSD: PROTOCOL.agent,v 1.21 2023/12/18 14:46:56 djm Exp $
+$OpenBSD: PROTOCOL.agent,v 1.22 2023/12/20 00:06:25 jsg Exp $

--- a/PROTOCOL.mux
+++ b/PROTOCOL.mux
@@ -188,8 +188,6 @@ For dynamically allocated listen port the server replies with
 
 7. Requesting closure of port forwards
 
-Note: currently unimplemented (server will always reply with MUX_S_FAILURE).
-
 A client may request the master to close a port forward:
 
 	uint32	MUX_C_CLOSE_FWD
@@ -295,4 +293,4 @@ XXX session inspection via master
 XXX signals via mux request
 XXX list active connections via mux
 
-$OpenBSD: PROTOCOL.mux,v 1.13 2022/01/01 01:55:30 jsg Exp $
+$OpenBSD: PROTOCOL.mux,v 1.14 2024/01/08 05:11:18 djm Exp $

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-See https://www.openssh.com/releasenotes.html#9.6p1 for the release
+See https://www.openssh.com/releasenotes.html#9.7p1 for the release
 notes.
 
 Please read https://www.openssh.com/report.html for bug reporting

--- a/README.platform
+++ b/README.platform
@@ -53,11 +53,12 @@ Darwin does not provide a tun(4) driver required for OpenSSH-based
 virtual private networks. The BSD manpage still exists, but the driver
 has been removed in recent releases of Darwin and MacOS X.
 
-Nevertheless, tunnel support is known to work with Darwin 8 and
-MacOS X 10.4 in Point-to-Point (Layer 3) and Ethernet (Layer 2) mode
-using a third party driver. More information is available at:
-	http://www-user.rhrk.uni-kl.de/~nissler/tuntap/
+Tunnel support is known to work with Darwin 8 and MacOS X 10.4 in
+Point-to-Point (Layer 3) and Ethernet (Layer 2) mode using a third
+party driver. More information is available at:
+	https://tuntaposx.sourceforge.net
 
+Recent Darwin/MacOS X versions are likely unsupported.
 
 Linux
 -----

--- a/binn.c
+++ b/binn.c
@@ -8,11 +8,13 @@
 #define UNUSED(x) (void)(x)
 #define roundval(dbl) dbl >= 0.0 ? (int)(dbl + 0.5) : ((dbl - (double)(int)dbl) <= -0.5 ? (int)dbl : (int)(dbl - 0.5))
 
+// magic number:  0x1F 0xb1 0x22 0x1F  =>  0x1FB1221F or 0x1F22B11F
+// because the BINN_STORAGE_NOBYTES (binary 000) may not have so many sub-types (BINN_STORAGE_HAS_MORE = 0x10)
 #define BINN_MAGIC            0x1F22B11F
 
-#define MAX_BINN_HEADER       9
-#define MIN_BINN_SIZE         3
-#define CHUNK_SIZE            256
+#define MAX_BINN_HEADER       9  // [1:type][4:size][4:count]
+#define MIN_BINN_SIZE         3  // [1:type][1:size][1:count]
+#define CHUNK_SIZE            256  // 1024
 
 #define BINN_STRUCT        1
 #define BINN_BUFFER        2
@@ -69,14 +71,14 @@ BINN_PRIVATE void copy_be16(u16 *pdest, u16 *psource) {
   unsigned char *dest = (unsigned char *) pdest;
   dest[0] = source[1];
   dest[1] = source[0];
-#else /*  if BYTE_ORDER == BIG_ENDIAN */
+#else // if BYTE_ORDER == BIG_ENDIAN
 #ifdef BINN_ONLY_ALIGNED_ACCESS
-  if ((uintptr_t)psource % 2 == 0){  /*  address aligned to 16 bit */
+  if ((uintptr_t)psource % 2 == 0){  // address aligned to 16 bit
     *pdest = *psource;
   } else {
     unsigned char *source = (unsigned char *) psource;
     unsigned char *dest = (unsigned char *) pdest;
-    dest[0] = source[0];  /*  indexes are the same */
+    dest[0] = source[0];  // indexes are the same
     dest[1] = source[1];
   }
 #else
@@ -93,14 +95,14 @@ BINN_PRIVATE void copy_be32(u32 *pdest, u32 *psource) {
   dest[1] = source[2];
   dest[2] = source[1];
   dest[3] = source[0];
-#else /*  if BYTE_ORDER == BIG_ENDIAN */
+#else // if BYTE_ORDER == BIG_ENDIAN
 #ifdef BINN_ONLY_ALIGNED_ACCESS
-  if ((uintptr_t)psource % 4 == 0){  /*  address aligned to 32 bit */
+  if ((uintptr_t)psource % 4 == 0){  // address aligned to 32 bit
     *pdest = *psource;
   } else {
     unsigned char *source = (unsigned char *) psource;
     unsigned char *dest = (unsigned char *) pdest;
-    dest[0] = source[0];  /*  indexes are the same */
+    dest[0] = source[0];  // indexes are the same
     dest[1] = source[1];
     dest[2] = source[2];
     dest[3] = source[3];
@@ -119,16 +121,16 @@ BINN_PRIVATE void copy_be64(u64 *pdest, u64 *psource) {
   for (i=0; i < 8; i++) {
     dest[i] = source[7-i];
   }
-#else /*  if BYTE_ORDER == BIG_ENDIAN */
+#else // if BYTE_ORDER == BIG_ENDIAN
 #ifdef BINN_ONLY_ALIGNED_ACCESS
-  if ((uintptr_t)psource % 8 == 0){  /*  address aligned to 64 bit */
+  if ((uintptr_t)psource % 8 == 0){  // address aligned to 64 bit
     *pdest = *psource;
   } else {
     unsigned char *source = (unsigned char *) psource;
     unsigned char *dest = (unsigned char *) pdest;
     int i;
     for (i=0; i < 8; i++) {
-      dest[i] = source[i];  /*  indexes are the same */
+      dest[i] = source[i];  // indexes are the same
     }
   }
 #else
@@ -144,7 +146,7 @@ BINN_PRIVATE void copy_be64(u64 *pdest, u64 *psource) {
 #define strnicmp strncasecmp
 #endif
 
-BINN_PRIVATE BOOL IsValidBinnHeader(void *pbuf, int *ptype, int *pcount, int *psize, int *pheadersize);
+BINN_PRIVATE BOOL IsValidBinnHeader(const void *pbuf, int *ptype, int *pcount, int *psize, int *pheadersize);
 
 /***************************************************************************/
 
@@ -181,7 +183,7 @@ BINN_PRIVATE void * binn_malloc(int size) {
 
 /***************************************************************************/
 
-BINN_PRIVATE void * binn_memdup(void *src, int size) {
+BINN_PRIVATE void * binn_memdup(const void *src, int size) {
   void *dest;
 
   if (src == NULL || size <= 0) return NULL;
@@ -205,7 +207,7 @@ BINN_PRIVATE size_t strlen2(char *str) {
 
 int APIENTRY binn_create_type(int storage_type, int data_type_index) {
   if (data_type_index < 0) return -1;
-  if ((storage_type < BINN_STORAGE_MIN) || (storage_type > BINN_STORAGE_MAX)) return -1;
+  if (storage_type < BINN_STORAGE_MIN || storage_type > BINN_STORAGE_MAX) return -1;
   if (data_type_index < 16)
     return storage_type | data_type_index;
   else if (data_type_index < 4096) {
@@ -236,8 +238,8 @@ again:
     extra_type = long_type & BINN_TYPE_MASK16;
     extra_type >>= 4;
   } else if (long_type & BINN_STORAGE_VIRTUAL) {
-    /* storage_type = BINN_STORAGE_VIRTUAL; */
-    /* extra_type = xxx; */
+    //storage_type = BINN_STORAGE_VIRTUAL;
+    //extra_type = xxx;
     long_type &= 0xffff;
     goto again;
   } else {
@@ -268,7 +270,7 @@ BOOL APIENTRY binn_create(binn *item, int type, int size, void *pointer) {
       goto loc_exit;
   }
 
-  if ((item == NULL) || (size < 0)) goto loc_exit;
+  if (item == NULL || size < 0) goto loc_exit;
   if (size < MIN_BINN_SIZE) {
     if (pointer) goto loc_exit;
     else size = 0;
@@ -278,24 +280,23 @@ BOOL APIENTRY binn_create(binn *item, int type, int size, void *pointer) {
 
   if (pointer) {
     item->pre_allocated = TRUE;
-    item->pbuf = pointer;
-    item->alloc_size = size;
   } else {
     item->pre_allocated = FALSE;
     if (size == 0) size = CHUNK_SIZE;
     pointer = binn_malloc(size);
     if (pointer == 0) return INVALID_BINN;
-    item->pbuf = pointer;
-    item->alloc_size = size;
   }
 
+  item->pbuf = pointer;
+  item->alloc_size = size;
+
   item->header = BINN_MAGIC;
-  /* item->allocated = FALSE;   -- already zeroed */
+  //item->allocated = FALSE;   -- already zeroed
   item->writable = TRUE;
-  item->used_size = MAX_BINN_HEADER;  /*  save space for the header */
+  item->used_size = MAX_BINN_HEADER;  // save space for the header
   item->type = type;
-  /* item->count = 0;           -- already zeroed */
-  item->dirty = TRUE;          /*  the header is not written to the buffer */
+  //item->count = 0;           -- already zeroed
+  item->dirty = TRUE;          // the header is not written to the buffer
 
   retval = TRUE;
 
@@ -365,7 +366,7 @@ binn * APIENTRY binn_object() {
 
 /***************************************************************************/
 
-binn * APIENTRY binn_copy(void *old) {
+binn * APIENTRY binn_copy(const void *old) {
   int type, count, size, header_size;
   unsigned char *old_ptr = binn_ptr(old);
   binn *item;
@@ -387,23 +388,39 @@ binn * APIENTRY binn_copy(void *old) {
 
 /*************************************************************************************/
 
-BOOL APIENTRY binn_load(void *data, binn *value) {
+// deprecated: unsecure. the size can be corrupted accidentally or intentionally
+BOOL APIENTRY binn_load(const void *data, binn *value) {
 
-  if ((data == NULL) || (value == NULL)) return FALSE;
+  if (data == NULL || value == NULL) return FALSE;
   memset(value, 0, sizeof(binn));
   value->header = BINN_MAGIC;
-  /* value->allocated = FALSE;  --  already zeroed */
-  /* value->writable = FALSE; */
+  //value->allocated = FALSE;  --  already zeroed
+  //value->writable = FALSE;
 
   if (binn_is_valid(data, &value->type, &value->count, &value->size) == FALSE) return FALSE;
-  value->ptr = data;
+  value->ptr = (void*) data;
+  return TRUE;
+
+}
+
+BOOL APIENTRY binn_load_ex(const void *data, int size, binn *value) {
+
+  if (data == NULL || value == NULL || size <= 0) return FALSE;
+  memset(value, 0, sizeof(binn));
+  value->header = BINN_MAGIC;
+  //value->allocated = FALSE;  --  already zeroed
+  //value->writable = FALSE;
+
+  if (binn_is_valid_ex(data, &value->type, &value->count, &size) == FALSE) return FALSE;
+  value->ptr = (void*) data;
+  value->size = size;
   return TRUE;
 
 }
 
 /*************************************************************************************/
 
-binn * APIENTRY binn_open(void *data) {
+binn * APIENTRY binn_open(const void *data) {
   binn *item;
 
   item = (binn*) binn_malloc(sizeof(binn));
@@ -418,9 +435,24 @@ binn * APIENTRY binn_open(void *data) {
 
 }
 
+binn * APIENTRY binn_open_ex(const void *data, int size) {
+  binn *item;
+
+  item = (binn*) binn_malloc(sizeof(binn));
+
+  if (binn_load_ex(data, size, item) == FALSE) {
+    free_fn(item);
+    return NULL;
+  }
+
+  item->allocated = TRUE;
+  return item;
+
+}
+
 /***************************************************************************/
 
-BINN_PRIVATE int binn_get_ptr_type(void *ptr) {
+BINN_PRIVATE int binn_get_ptr_type(const void *ptr) {
 
   if (ptr == NULL) return 0;
 
@@ -435,7 +467,7 @@ BINN_PRIVATE int binn_get_ptr_type(void *ptr) {
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_is_struct(void *ptr) {
+BOOL APIENTRY binn_is_struct(const void *ptr) {
 
   if (ptr == NULL) return FALSE;
 
@@ -454,8 +486,8 @@ BINN_PRIVATE int CalcAllocation(int needed_size, int alloc_size) {
 
   calc_size = alloc_size;
   while (calc_size < needed_size) {
-    calc_size <<= 1;  /*  same as *= 2 */
-    /* calc_size += CHUNK_SIZE;  -- this is slower than the above line, because there are more reallocations */
+    calc_size <<= 1;  // same as *= 2
+    //calc_size += CHUNK_SIZE;  -- this is slower than the above line, because there are more reallocations
   }
   return calc_size;
 
@@ -519,7 +551,7 @@ BINN_PRIVATE unsigned char * AdvanceDataPos(unsigned char *p, unsigned char *pli
 
   switch (storage_type) {
   case BINN_STORAGE_NOBYTES:
-    /* p += 0; */
+    //p += 0;
     break;
   case BINN_STORAGE_BYTE:
     p ++;
@@ -547,7 +579,7 @@ BINN_PRIVATE unsigned char * AdvanceDataPos(unsigned char *p, unsigned char *pli
     }
     p += DataSize;
     if (storage_type == BINN_STORAGE_STRING) {
-      p++;  /*  null terminator. */
+      p++;  // null terminator.
     }
     break;
   case BINN_STORAGE_CONTAINER:
@@ -558,14 +590,12 @@ BINN_PRIVATE unsigned char * AdvanceDataPos(unsigned char *p, unsigned char *pli
       copy_be32((u32*)&DataSize, (u32*)p);
       DataSize &= 0x7FFFFFFF;
     }
-    DataSize--;  /*  remove the type byte already added before */
+    DataSize--;  // remove the type byte already added before
     p += DataSize;
     break;
   default:
     return 0;
   }
-
-  if (p > plimit) return 0;
 
   return p;
 
@@ -592,6 +622,7 @@ BINN_PRIVATE int read_map_id(unsigned char **pp, unsigned char *plimit) {
   int id, extra_bytes;
 
   p = *pp;
+  if (p > plimit) return 0;
 
   c = *p++;
 
@@ -646,15 +677,15 @@ BINN_PRIVATE unsigned char * SearchForID(unsigned char *p, int header_size, int 
   plimit = p + size - 1;
   p += header_size;
 
-  /*  search for the ID in all the arguments. */
+  // search for the ID in all the arguments.
   for (i = 0; i < numitems; i++) {
     int32 = read_map_id(&p, plimit);
     if (p > plimit) break;
-    /*  Compare if the IDs are equal. */
+    // Compare if the IDs are equal.
     if (int32 == id) return p;
-    /*  xxx */
+    // xxx
     p = AdvanceDataPos(p, plimit);
-    if ((p == 0) || (p < base)) break;
+    if (p == 0 || p < base) break;
   }
 
   return NULL;
@@ -673,27 +704,27 @@ BINN_PRIVATE unsigned char * SearchForKey(unsigned char *p, int header_size, int
 
   keylen = strlen(key);
 
-  /*  search for the key in all the arguments. */
+  // search for the key in all the arguments.
   for (i = 0; i < numitems; i++) {
+    if (p > plimit) break;
     len = *((unsigned char *)p);
     p++;
-    if (p > plimit) break;
-    /*  Compare if the strings are equal. */
+    if (p + len > plimit) break;
+    // Compare if the strings are equal.
     if (len > 0) {
-      if (strnicmp((char*)p, key, len) == 0) {   /*  note that there is no null terminator here */
+      if (strnicmp((char*)p, key, len) == 0) {   // note that there is no null terminator here
         if (keylen == len) {
           p += len;
           return p;
         }
       }
       p += len;
-      if (p > plimit) break;
-    } else if (len == keylen) {   /*  in the case of empty string: "" */
+    } else if (len == keylen) {   // in the case of empty string: ""
       return p;
     }
-    /*  xxx */
+    // xxx
     p = AdvanceDataPos(p, plimit);
-    if ((p == 0) || (p < base)) break;
+    if (p == 0 || p < base) break;
   }
 
   return NULL;
@@ -708,9 +739,9 @@ BINN_PRIVATE BOOL AddValue(binn *item, int type, void *pvalue, int size);
 
 BINN_PRIVATE BOOL binn_list_add_raw(binn *item, int type, void *pvalue, int size) {
 
-  if ((item == NULL) || (item->type != BINN_LIST) || (item->writable == FALSE)) return FALSE;
+  if (item == NULL || item->type != BINN_LIST || item->writable == FALSE) return FALSE;
 
-  /* if (CheckAllocation(item, 4) == FALSE) return FALSE;  // 4 bytes used for data_store and data_format. */
+  //if (CheckAllocation(item, 4) == FALSE) return FALSE;  // 4 bytes used for data_store and data_format.
 
   if (AddValue(item, type, pvalue, size) == FALSE) return FALSE;
 
@@ -726,26 +757,26 @@ BINN_PRIVATE BOOL binn_object_set_raw(binn *item, const char *key, int type, voi
   unsigned char *p, len;
   int int32;
 
-  if ((item == NULL) || (item->type != BINN_OBJECT) || (item->writable == FALSE)) return FALSE;
+  if (item == NULL || item->type != BINN_OBJECT || item->writable == FALSE) return FALSE;
 
   if (key == NULL) return FALSE;
   int32 = strlen(key);
   if (int32 > 255) return FALSE;
 
-  /*  is the key already in it? */
+  // is the key already in it?
   p = SearchForKey(item->pbuf, MAX_BINN_HEADER, item->used_size, item->count, key);
   if (p) return FALSE;
 
-  /*  start adding it */
+  // start adding it
 
-  if (CheckAllocation(item, 1 + int32) == FALSE) return FALSE;  /*  bytes used for the key size and the key itself. */
+  if (CheckAllocation(item, 1 + int32) == FALSE) return FALSE;  // bytes used for the key size and the key itself.
 
   p = ((unsigned char *) item->pbuf) + item->used_size;
   len = int32;
   *p = len;
   p++;
   memcpy(p, key, int32);
-  int32++;  /*  now contains the strlen + 1 byte for the len */
+  int32++;  // now contains the strlen + 1 byte for the len
   item->used_size += int32;
 
   if (AddValue(item, type, pvalue, size) == FALSE) {
@@ -765,15 +796,15 @@ BINN_PRIVATE BOOL binn_map_set_raw(binn *item, int id, int type, void *pvalue, i
   unsigned char *base, *p, sign;
   int id_size;
 
-  if ((item == NULL) || (item->type != BINN_MAP) || (item->writable == FALSE)) return FALSE;
+  if (item == NULL || item->type != BINN_MAP || item->writable == FALSE) return FALSE;
 
-  /*  is the ID already in it? */
+  // is the ID already in it?
   p = SearchForID(item->pbuf, MAX_BINN_HEADER, item->used_size, item->count, id);
   if (p) return FALSE;
 
-  /*  start adding it */
+  // start adding it
 
-  if (CheckAllocation(item, 5) == FALSE) return FALSE;  /*  max 5 bytes used for the id. */
+  if (CheckAllocation(item, 5) == FALSE) return FALSE;  // max 5 bytes used for the id.
 
   p = base = ((unsigned char *) item->pbuf) + item->used_size;
 
@@ -859,7 +890,7 @@ loc_signed:
     goto loc_positive;
   }
 
-/* loc_negative: */
+//loc_negative:
 
   if (vint >= INT8_MIN) {
     type2 = BINN_INT8;
@@ -888,7 +919,7 @@ loc_exit:
 
   pvalue = (char *) psource;
 
-  if ((type2) && (type2 != type)) {
+  if (type2 && type2 != type) {
     *ptype = type2;
     storage_type2 = binn_get_write_storage(type2);
     *pstorage_type = storage_type2;
@@ -919,14 +950,14 @@ BINN_PRIVATE BOOL AddValue(binn *item, int type, void *pvalue, int size) {
         break;
       case BINN_STORAGE_BLOB:
       case BINN_STORAGE_STRING:
-        if (size == 0) break; /*  the 2 above are allowed to have 0 length */
+        if (size == 0) break; // the 2 above are allowed to have 0 length
 	/* fall through */
       default:
         return FALSE;
     }
   }
 
-  if ((type_family(type) == BINN_FAMILY_INT) && (item->disable_int_compression == FALSE))
+  if (type_family(type) == BINN_FAMILY_INT && item->disable_int_compression == FALSE)
     pvalue = compress_int(&storage_type, &type, pvalue);
 
   switch (storage_type) {
@@ -952,13 +983,13 @@ BINN_PRIVATE BOOL AddValue(binn *item, int type, void *pvalue, int size) {
       break;
     case BINN_STORAGE_BLOB:
       if (size < 0) return FALSE;
-      /* if (size == 0) ... */
-      ArgSize = size + 4; /*  at least this size */
+      //if (size == 0) ...
+      ArgSize = size + 4; // at least this size
       break;
     case BINN_STORAGE_STRING:
       if (size < 0) return FALSE;
       if (size == 0) size = strlen2( (char *) pvalue);
-      ArgSize = size + 5; /*  at least this size */
+      ArgSize = size + 5; // at least this size
       break;
     case BINN_STORAGE_CONTAINER:
       if (size <= 0) return FALSE;
@@ -968,13 +999,13 @@ BINN_PRIVATE BOOL AddValue(binn *item, int type, void *pvalue, int size) {
       return FALSE;
   }
 
-  ArgSize += 2;  /*  at least 2 bytes used for data_type. */
+  ArgSize += 2;  // at least 2 bytes used for data_type.
   if (CheckAllocation(item, ArgSize) == FALSE) return FALSE;
 
-  /*  Gets the pointer to the next place in buffer */
+  // Gets the pointer to the next place in buffer
   p = ((unsigned char *) item->pbuf) + item->used_size;
 
-  /*  If the data is not a container, store the data type */
+  // If the data is not a container, store the data type
   if (storage_type != BINN_STORAGE_CONTAINER) {
     if (type > 255) {
       u16 type16 = type;
@@ -990,7 +1021,7 @@ BINN_PRIVATE BOOL AddValue(binn *item, int type, void *pvalue, int size) {
 
   switch (storage_type) {
     case BINN_STORAGE_NOBYTES:
-      /*  Nothing to do. */
+      // Nothing to do.
       break;
     case BINN_STORAGE_BYTE:
       *((char *) p) = *((char *) pvalue);
@@ -1024,7 +1055,7 @@ BINN_PRIVATE BOOL AddValue(binn *item, int type, void *pvalue, int size) {
       if (storage_type == BINN_STORAGE_STRING) {
         p += size;
         *((char *) p) = (char) 0;
-        size++;  /*  null terminator */
+        size++;  // null terminator
       }
       item->used_size += size;
       break;
@@ -1050,9 +1081,9 @@ BINN_PRIVATE BOOL binn_save_header(binn *item) {
 #ifndef BINN_DISABLE_SMALL_HEADER
 
   p = ((unsigned char *) item->pbuf) + MAX_BINN_HEADER;
-  size = item->used_size - MAX_BINN_HEADER + 3;  /*  at least 3 bytes for the header */
+  size = item->used_size - MAX_BINN_HEADER + 3;  // at least 3 bytes for the header
 
-  /*  write the count */
+  // write the count
   if (item->count > 127) {
     p -= 4;
     size += 3;
@@ -1063,7 +1094,7 @@ BINN_PRIVATE BOOL binn_save_header(binn *item) {
     *p = (unsigned char) item->count;
   }
 
-  /*  write the size */
+  // write the size
   if (size > 127) {
     p -= 4;
     size += 3;
@@ -1074,11 +1105,11 @@ BINN_PRIVATE BOOL binn_save_header(binn *item) {
     *p = (unsigned char) size;
   }
 
-  /*  write the type. */
+  // write the type.
   p--;
   *p = (unsigned char) item->type;
 
-  /*  set the values */
+  // set the values
   item->ptr = p;
   item->size = size;
 
@@ -1088,14 +1119,14 @@ BINN_PRIVATE BOOL binn_save_header(binn *item) {
 
   p = (unsigned char *) item->pbuf;
 
-  /*  write the type. */
+  // write the type.
   byte = item->type;
   *p = byte; p++;
-  /*  write the size */
+  // write the size
   int32 = item->used_size | 0x80000000;
   copy_be32((u32*)p, (u32*)&int32);
   p+=4;
-  /*  write the count */
+  // write the count
   int32 = item->count | 0x80000000;
   copy_be32((u32*)p, (u32*)&int32);
 
@@ -1116,7 +1147,7 @@ void APIENTRY binn_free(binn *item) {
 
   if (item == NULL) return;
 
-  if ((item->writable) && (item->pre_allocated == FALSE)) {
+  if (item->writable && item->pre_allocated == FALSE) {
     free_fn(item->pbuf);
   }
 
@@ -1132,7 +1163,7 @@ void APIENTRY binn_free(binn *item) {
 }
 
 /***************************************************************************/
-/*  free the binn structure but keeps the binn buffer allocated, returning a pointer to it. use the free function to release the buffer later */
+// free the binn structure but keeps the binn buffer allocated, returning a pointer to it. use the free function to release the buffer later
 void * APIENTRY binn_release(binn *item) {
   void *data;
 
@@ -1158,7 +1189,7 @@ void * APIENTRY binn_release(binn *item) {
 
 /***************************************************************************/
 
-BINN_PRIVATE BOOL IsValidBinnHeader(void *pbuf, int *ptype, int *pcount, int *psize, int *pheadersize) {
+BINN_PRIVATE BOOL IsValidBinnHeader(const void *pbuf, int *ptype, int *pcount, int *psize, int *pheadersize) {
   unsigned char byte, *p, *plimit=0;
   int int32, type, size, count;
 
@@ -1167,10 +1198,11 @@ BINN_PRIVATE BOOL IsValidBinnHeader(void *pbuf, int *ptype, int *pcount, int *ps
   p = (unsigned char *) pbuf;
 
   if (psize && *psize > 0) {
+    if (*psize < MIN_BINN_SIZE) return FALSE;
     plimit = p + *psize - 1;
   }
 
-  /*  get the type */
+  // get the type
   byte = *p; p++;
   if ((byte & BINN_STORAGE_MASK) != BINN_STORAGE_CONTAINER) return FALSE;
   if (byte & BINN_STORAGE_HAS_MORE) return FALSE;
@@ -1185,7 +1217,7 @@ BINN_PRIVATE BOOL IsValidBinnHeader(void *pbuf, int *ptype, int *pcount, int *ps
       return FALSE;
   }
 
-  /*  get the size */
+  // get the size
   if (plimit && p > plimit) return FALSE;
   int32 = *((unsigned char*)p);
   if (int32 & 0x80) {
@@ -1198,7 +1230,7 @@ BINN_PRIVATE BOOL IsValidBinnHeader(void *pbuf, int *ptype, int *pcount, int *ps
   }
   size = int32;
 
-  /*  get the count */
+  // get the count
   if (plimit && p > plimit) return FALSE;
   int32 = *((unsigned char*)p);
   if (int32 & 0x80) {
@@ -1211,31 +1243,19 @@ BINN_PRIVATE BOOL IsValidBinnHeader(void *pbuf, int *ptype, int *pcount, int *ps
   }
   count = int32;
 
-#if 0
-  /*  get the size */
-  copy_be32((u32*)&size, (u32*)p);
-  size &= 0x7FFFFFFF;
-  p+=4;
+  if (size < MIN_BINN_SIZE || count < 0) return FALSE;
 
-  /*  get the count */
-  copy_be32((u32*)&count, (u32*)p);
-  count &= 0x7FFFFFFF;
-  p+=4;
-#endif
-
-  if ((size < MIN_BINN_SIZE) || (count < 0)) return FALSE;
-
-  /*  return the values */
+  // return the values
   if (ptype)  *ptype  = type;
   if (pcount) *pcount = count;
-  if (psize && *psize==0) *psize = size;
+  if (psize)  *psize  = size;
   if (pheadersize) *pheadersize = (int) (p - (unsigned char*)pbuf);
   return TRUE;
 }
 
 /***************************************************************************/
 
-BINN_PRIVATE int binn_buf_type(void *pbuf) {
+BINN_PRIVATE int binn_buf_type(const void *pbuf) {
   int  type;
 
   if (!IsValidBinnHeader(pbuf, &type, NULL, NULL, NULL)) return INVALID_BINN;
@@ -1246,7 +1266,7 @@ BINN_PRIVATE int binn_buf_type(void *pbuf) {
 
 /***************************************************************************/
 
-BINN_PRIVATE int binn_buf_count(void *pbuf) {
+BINN_PRIVATE int binn_buf_count(const void *pbuf) {
   int  nitems;
 
   if (!IsValidBinnHeader(pbuf, NULL, &nitems, NULL, NULL)) return 0;
@@ -1257,7 +1277,7 @@ BINN_PRIVATE int binn_buf_count(void *pbuf) {
 
 /***************************************************************************/
 
-BINN_PRIVATE int binn_buf_size(void *pbuf) {
+BINN_PRIVATE int binn_buf_size(const void *pbuf) {
   int  size=0;
 
   if (!IsValidBinnHeader(pbuf, NULL, NULL, &size, NULL)) return 0;
@@ -1268,7 +1288,7 @@ BINN_PRIVATE int binn_buf_size(void *pbuf) {
 
 /***************************************************************************/
 
-void * APIENTRY binn_ptr(void *ptr) {
+void * APIENTRY binn_ptr(const void *ptr) {
   binn *item;
 
   switch (binn_get_ptr_type(ptr)) {
@@ -1279,7 +1299,7 @@ void * APIENTRY binn_ptr(void *ptr) {
     }
     return item->ptr;
   case BINN_BUFFER:
-    return ptr;
+    return (void*)ptr;
   default:
     return NULL;
   }
@@ -1288,7 +1308,7 @@ void * APIENTRY binn_ptr(void *ptr) {
 
 /***************************************************************************/
 
-int APIENTRY binn_size(void *ptr) {
+int APIENTRY binn_size(const void *ptr) {
   binn *item;
 
   switch (binn_get_ptr_type(ptr)) {
@@ -1308,7 +1328,7 @@ int APIENTRY binn_size(void *ptr) {
 
 /***************************************************************************/
 
-int APIENTRY binn_type(void *ptr) {
+int APIENTRY binn_type(const void *ptr) {
   binn *item;
 
   switch (binn_get_ptr_type(ptr)) {
@@ -1325,7 +1345,7 @@ int APIENTRY binn_type(void *ptr) {
 
 /***************************************************************************/
 
-int APIENTRY binn_count(void *ptr) {
+int APIENTRY binn_count(const void *ptr) {
   binn *item;
 
   switch (binn_get_ptr_type(ptr)) {
@@ -1342,73 +1362,83 @@ int APIENTRY binn_count(void *ptr) {
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_is_valid_ex(void *ptr, int *ptype, int *pcount, int *psize) {
+// the container can be smaller than the informed size
+BINN_PRIVATE BOOL binn_is_valid_ex2(const void *ptr, int *ptype, int *pcount, int *psize) {
   int  i, type, count, size, header_size;
   unsigned char *p, *plimit, *base, len;
-  void *pbuf;
 
-  pbuf = binn_ptr(ptr);
-  if (pbuf == NULL) return FALSE;
+  if (ptr == NULL) return FALSE;
 
-  /*  is there an informed size? */
+  // is there an informed size?
   if (psize && *psize > 0) {
     size = *psize;
   } else {
     size = 0;
   }
 
-  if (!IsValidBinnHeader(pbuf, &type, &count, &size, &header_size)) return FALSE;
+  if (!IsValidBinnHeader(ptr, &type, &count, &size, &header_size)) return FALSE;
 
-  /*  is there an informed size? */
+  // is there an informed size?
   if (psize && *psize > 0) {
-    /*  is it the same as the one in the buffer? */
-    if (size != *psize) return FALSE;
+    // is it bigger than the buffer?
+    if (size > *psize) return FALSE;
   }
-  /*  is there an informed count? */
+  // is there an informed count?
   if (pcount && *pcount > 0) {
-    /*  is it the same as the one in the buffer? */
+    // is it the same as the one in the buffer?
     if (count != *pcount) return FALSE;
   }
-  /*  is there an informed type? */
+  // is there an informed type?
   if (ptype && *ptype != 0) {
-    /*  is it the same as the one in the buffer? */
+    // is it the same as the one in the buffer?
     if (type != *ptype) return FALSE;
   }
 
-  /*  it could compare the content size with the size informed on the header */
-
-  p = (unsigned char *)pbuf;
+  p = (unsigned char *)ptr;
   base = p;
-  plimit = p + size;
+  plimit = p + size - 1;
 
   p += header_size;
 
-  /*  process all the arguments. */
+  // process each (key and) value
   for (i = 0; i < count; i++) {
     switch (type) {
       case BINN_OBJECT:
-        /*  gets the string size (argument name) */
+        if (p > plimit) goto Invalid;
+        // get the key (string) size
         len = *p;
         p++;
-        /* if (len == 0) goto Invalid; */
-        /*  increment the used space */
+        //if (len == 0) goto Invalid;
+        // advance over the key
         p += len;
         break;
       case BINN_MAP:
-        /*  increment the used space */
+        // advance over the key
         read_map_id(&p, plimit);
         break;
-      /* case BINN_LIST: */
-      /*   break; */
+      case BINN_LIST:
+        // no key
+        break;
+      default:
+        goto Invalid;
     }
-    /*  xxx */
-    p = AdvanceDataPos(p, plimit);
-    if ((p == 0) || (p < base)) goto Invalid;
+    // check the value
+    if (p > plimit) goto Invalid;
+    if ((*p & BINN_STORAGE_MASK) == BINN_STORAGE_CONTAINER) {
+      // recursively check the internal container
+      int size2 = plimit - p + 1;  // maximum container size
+      if (binn_is_valid_ex2(p, NULL, NULL, &size2) == FALSE) goto Invalid;
+      p += size2;
+    } else {
+      // advance over the value
+      p = AdvanceDataPos(p, plimit);
+      if (p == 0 || p < base) goto Invalid;
+    }
   }
 
-  if (ptype  && *ptype==0)  *ptype  = type;
+  if (ptype  && *ptype==0) *ptype = type;
   if (pcount && *pcount==0) *pcount = count;
-  if (psize  && *psize==0)  *psize  = size;
+  if (psize) *psize = size;
   return TRUE;
 
 Invalid:
@@ -1416,9 +1446,32 @@ Invalid:
 
 }
 
+// the container must have the informed size, if informed
+BOOL APIENTRY binn_is_valid_ex(const void *ptr, int *ptype, int *pcount, int *psize) {
+  int size;
+
+  if (psize && *psize > 0) {
+    size = *psize;
+  } else {
+    size = 0;
+  }
+
+  if (binn_is_valid_ex2(ptr, ptype, pcount, &size) == FALSE) return FALSE;
+
+  if (psize) {
+    if (*psize > 0) {
+      if (size != *psize) return FALSE;
+    } else if (*psize==0) {
+      *psize = size;
+    }
+  }
+
+  return TRUE;
+}
+
 /***************************************************************************/
 
-BOOL APIENTRY binn_is_valid(void *ptr, int *ptype, int *pcount, int *psize) {
+BOOL APIENTRY binn_is_valid(const void *ptr, int *ptype, int *pcount, int *psize) {
 
   if (ptype)  *ptype  = 0;
   if (pcount) *pcount = 0;
@@ -1432,78 +1485,87 @@ BOOL APIENTRY binn_is_valid(void *ptr, int *ptype, int *pcount, int *psize) {
 /*** INTERNAL FUNCTIONS ****************************************************/
 /***************************************************************************/
 
-BINN_PRIVATE BOOL GetValue(unsigned char *p, binn *value) {
+BINN_PRIVATE BOOL GetValue(unsigned char *p, unsigned char *plimit, binn *value) {
   unsigned char byte;
-  int   data_type, storage_type;  /* , extra_type; */
+  int   data_type, storage_type;  //, extra_type;
   int   DataSize;
   void *p2;
 
   if (value == NULL) return FALSE;
   memset(value, 0, sizeof(binn));
   value->header = BINN_MAGIC;
-  /* value->allocated = FALSE;  --  already zeroed */
-  /* value->writable = FALSE; */
+  //value->allocated = FALSE;  --  already zeroed
+  //value->writable = FALSE;
 
-  /*  saves for use with BINN_STORAGE_CONTAINER */
+  // saves for use with BINN_STORAGE_CONTAINER
   p2 = p;
 
-  /*  read the data type */
+  // read the data type
+  if (p > plimit) return FALSE;
   byte = *p; p++;
   storage_type = byte & BINN_STORAGE_MASK;
   if (byte & BINN_STORAGE_HAS_MORE) {
     data_type = byte << 8;
+    if (p > plimit) return FALSE;
     byte = *p; p++;
     data_type |= byte;
-    /* extra_type = data_type & BINN_TYPE_MASK16; */
+    //extra_type = data_type & BINN_TYPE_MASK16;
   } else {
     data_type = byte;
-    /* extra_type = byte & BINN_TYPE_MASK; */
+    //extra_type = byte & BINN_TYPE_MASK;
   }
 
-  /* value->storage_type = storage_type; */
+  //value->storage_type = storage_type;
   value->type = data_type;
 
   switch (storage_type) {
   case BINN_STORAGE_NOBYTES:
     break;
   case BINN_STORAGE_BYTE:
+    if (p > plimit) return FALSE;
     value->vuint8 = *((unsigned char *) p);
-    value->ptr = p;   /* value->ptr = &value->vuint8; */
+    value->ptr = p;   //value->ptr = &value->vuint8;
     break;
   case BINN_STORAGE_WORD:
+    if (p + 1 > plimit) return FALSE;
     copy_be16((u16*)&value->vint16, (u16*)p);
     value->ptr = &value->vint16;
     break;
   case BINN_STORAGE_DWORD:
+    if (p + 3 > plimit) return FALSE;
     copy_be32((u32*)&value->vint32, (u32*)p);
     value->ptr = &value->vint32;
     break;
   case BINN_STORAGE_QWORD:
+    if (p + 7 > plimit) return FALSE;
     copy_be64((u64*)&value->vint64, (u64*)p);
     value->ptr = &value->vint64;
     break;
   case BINN_STORAGE_BLOB:
   case BINN_STORAGE_STRING:
+    if (p > plimit) return FALSE;
     DataSize = *((unsigned char*)p);
     if (DataSize & 0x80) {
+      if (p + 3 > plimit) return FALSE;
       copy_be32((u32*)&DataSize, (u32*)p);
       DataSize &= 0x7FFFFFFF;
       p+=4;
     } else {
       p++;
     }
+    if (p + DataSize - 1 > plimit) return FALSE;
     value->size = DataSize;
     value->ptr = p;
     break;
   case BINN_STORAGE_CONTAINER:
-    value->ptr = p2;  /*  <-- it returns the pointer to the container, not the data */
+    value->ptr = p2;  // <-- it returns the pointer to the container, not the data
     if (IsValidBinnHeader(p2, NULL, &value->count, &value->size, NULL) == FALSE) return FALSE;
     break;
   default:
     return FALSE;
   }
 
-  /*  convert the returned value, if needed */
+  // convert the returned value, if needed
 
   switch (value->type) {
     case BINN_TRUE:
@@ -1519,12 +1581,12 @@ BINN_PRIVATE BOOL GetValue(unsigned char *p, binn *value) {
 #ifdef BINN_EXTENDED
     case BINN_SINGLE_STR:
       value->type = BINN_SINGLE;
-      value->vfloat = (float) atof((const char*)value->ptr);  /*  converts from string to double, and then to float */
+      value->vfloat = (float) atof((const char*)value->ptr);  // converts from string to double, and then to float
       value->ptr = &value->vfloat;
       break;
     case BINN_DOUBLE_STR:
       value->type = BINN_DOUBLE;
-      value->vdouble = atof((const char*)value->ptr);  /*  converts from string to double */
+      value->vdouble = atof((const char*)value->ptr);  // converts from string to double
       value->ptr = &value->vdouble;
       break;
 #endif
@@ -1545,8 +1607,8 @@ BINN_PRIVATE BOOL GetValue(unsigned char *p, binn *value) {
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 
-/*  on little-endian devices we store the value so we can return a pointer to integers. */
-/*  it's valid only for single-threaded apps. multi-threaded apps must use the _get_ functions instead. */
+// on little-endian devices we store the value so we can return a pointer to integers.
+// it's valid only for single-threaded apps. multi-threaded apps must use the _get_ functions instead.
 
 binn local_value;
 
@@ -1556,14 +1618,14 @@ BINN_PRIVATE void * store_value(binn *value) {
 
   switch (binn_get_read_storage(value->type)) {
   case BINN_STORAGE_NOBYTES:
-    /*  return a valid pointer */
+    // return a valid pointer
   case BINN_STORAGE_WORD:
   case BINN_STORAGE_DWORD:
   case BINN_STORAGE_QWORD:
-    return &local_value.vint32;  /*  returns the pointer to the converted value, from big-endian to little-endian */
+    return &local_value.vint32;  // returns the pointer to the converted value, from big-endian to little-endian
   }
 
-  return value->ptr;   /*  returns from the on stack value to be thread-safe (for list, map, object, string and blob) */
+  return value->ptr;   // returns from the on stack value to be thread-safe (for list, map, object, string and blob)
 
 }
 
@@ -1573,78 +1635,82 @@ BINN_PRIVATE void * store_value(binn *value) {
 /*** READ FUNCTIONS ********************************************************/
 /***************************************************************************/
 
-BOOL APIENTRY binn_object_get_value(void *ptr, const char *key, binn *value) {
+BOOL APIENTRY binn_object_get_value(const void *ptr, const char *key, binn *value) {
   int type, count, size=0, header_size;
-  unsigned char *p;
+  unsigned char *p, *plimit;
 
   ptr = binn_ptr(ptr);
-  if ((ptr == 0) || (key == 0) || (value == 0)) return FALSE;
+  if (ptr == NULL || key == NULL || value == NULL) return FALSE;
 
-  /*  check the header */
+  // check the header
   if (IsValidBinnHeader(ptr, &type, &count, &size, &header_size) == FALSE) return FALSE;
 
   if (type != BINN_OBJECT) return FALSE;
   if (count == 0) return FALSE;
 
   p = (unsigned char *) ptr;
+  plimit = p + size - 1;
+
   p = SearchForKey(p, header_size, size, count, key);
   if (p == FALSE) return FALSE;
 
-  return GetValue(p, value);
+  return GetValue(p, plimit, value);
 
 }
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_map_get_value(void* ptr, int id, binn *value) {
+BOOL APIENTRY binn_map_get_value(const void *ptr, int id, binn *value) {
   int type, count, size=0, header_size;
-  unsigned char *p;
+  unsigned char *p, *plimit;
 
   ptr = binn_ptr(ptr);
-  if ((ptr == 0) || (value == 0)) return FALSE;
+  if (ptr == NULL || value == NULL) return FALSE;
 
-  /*  check the header */
+  // check the header
   if (IsValidBinnHeader(ptr, &type, &count, &size, &header_size) == FALSE) return FALSE;
 
   if (type != BINN_MAP) return FALSE;
   if (count == 0) return FALSE;
 
   p = (unsigned char *) ptr;
+  plimit = p + size - 1;
+
   p = SearchForID(p, header_size, size, count, id);
   if (p == FALSE) return FALSE;
 
-  return GetValue(p, value);
+  return GetValue(p, plimit, value);
 
 }
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_list_get_value(void* ptr, int pos, binn *value) {
+BOOL APIENTRY binn_list_get_value(const void *ptr, int pos, binn *value) {
   int  i, type, count, size=0, header_size;
   unsigned char *p, *plimit, *base;
 
   ptr = binn_ptr(ptr);
-  if ((ptr == 0) || (value == 0)) return FALSE;
+  if (ptr == NULL || value == NULL) return FALSE;
 
-  /*  check the header */
+  // check the header
   if (IsValidBinnHeader(ptr, &type, &count, &size, &header_size) == FALSE) return FALSE;
 
   if (type != BINN_LIST) return FALSE;
   if (count == 0) return FALSE;
-  if ((pos <= 0) | (pos > count)) return FALSE;
-  pos--;  /*  convert from base 1 to base 0 */
+  if (pos <= 0 || pos > count) return FALSE;
+  pos--;  // convert from base 1 to base 0
 
   p = (unsigned char *) ptr;
   base = p;
-  plimit = p + size;
+  plimit = p + size - 1;
   p += header_size;
 
   for (i = 0; i < pos; i++) {
     p = AdvanceDataPos(p, plimit);
-    if ((p == 0) || (p < base)) return FALSE;
+    if (p == 0 || p < base) return FALSE;
   }
 
-  return GetValue(p, value);
+  return GetValue(p, plimit, value);
 
 }
 
@@ -1652,17 +1718,17 @@ BOOL APIENTRY binn_list_get_value(void* ptr, int pos, binn *value) {
 /*** READ PAIR BY POSITION *************************************************/
 /***************************************************************************/
 
-BINN_PRIVATE BOOL binn_read_pair(int expected_type, void *ptr, int pos, int *pid, char *pkey, binn *value) {
+BINN_PRIVATE BOOL binn_read_pair(int expected_type, const void *ptr, int pos, int *pid, char *pkey, binn *value) {
   int  type, count, size=0, header_size;
   int  i, int32, id = 0, counter=0;
   unsigned char *p, *plimit, *base, *key = NULL, len = 0;
 
   ptr = binn_ptr(ptr);
 
-  /*  check the header */
+  // check the header
   if (IsValidBinnHeader(ptr, &type, &count, &size, &header_size) == FALSE) return FALSE;
 
-  if ((type != expected_type) || (count == 0) || (pos < 1) || (pos > count)) return FALSE;
+  if (type != expected_type || count == 0 || pos < 1 || pos > count) return FALSE;
 
   p = (unsigned char *) ptr;
   base = p;
@@ -1686,9 +1752,9 @@ BINN_PRIVATE BOOL binn_read_pair(int expected_type, void *ptr, int pos, int *pid
     }
     counter++;
     if (counter == pos) goto found;
-    /*  */
+    //
     p = AdvanceDataPos(p, plimit);
-    if ((p == 0) || (p < base)) return FALSE;
+    if (p == 0 || p < base) return FALSE;
   }
 
   return FALSE;
@@ -1707,13 +1773,13 @@ found:
       break;
   }
 
-  return GetValue(p, value);
+  return GetValue(p, plimit, value);
 
 }
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_map_get_pair(void *ptr, int pos, int *pid, binn *value) {
+BOOL APIENTRY binn_map_get_pair(const void *ptr, int pos, int *pid, binn *value) {
 
   return binn_read_pair(BINN_MAP, ptr, pos, pid, NULL, value);
 
@@ -1721,7 +1787,7 @@ BOOL APIENTRY binn_map_get_pair(void *ptr, int pos, int *pid, binn *value) {
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_object_get_pair(void *ptr, int pos, char *pkey, binn *value) {
+BOOL APIENTRY binn_object_get_pair(const void *ptr, int pos, char *pkey, binn *value) {
 
   return binn_read_pair(BINN_OBJECT, ptr, pos, NULL, pkey, value);
 
@@ -1729,7 +1795,7 @@ BOOL APIENTRY binn_object_get_pair(void *ptr, int pos, char *pkey, binn *value) 
 
 /***************************************************************************/
 
-binn * APIENTRY binn_map_pair(void *map, int pos, int *pid) {
+binn * APIENTRY binn_map_pair(const void *map, int pos, int *pid) {
   binn *value;
 
   value = (binn *) binn_malloc(sizeof(binn));
@@ -1746,7 +1812,7 @@ binn * APIENTRY binn_map_pair(void *map, int pos, int *pid) {
 
 /***************************************************************************/
 
-binn * APIENTRY binn_object_pair(void *obj, int pos, char *pkey) {
+binn * APIENTRY binn_object_pair(const void *obj, int pos, char *pkey) {
   binn *value;
 
   value = (binn *) binn_malloc(sizeof(binn));
@@ -1764,7 +1830,7 @@ binn * APIENTRY binn_object_pair(void *obj, int pos, char *pkey) {
 /***************************************************************************/
 /***************************************************************************/
 
-void * APIENTRY binn_map_read_pair(void *ptr, int pos, int *pid, int *ptype, int *psize) {
+void * APIENTRY binn_map_read_pair(const void *ptr, int pos, int *pid, int *ptype, int *psize) {
   binn value;
 
   if (binn_map_get_pair(ptr, pos, pid, &value) == FALSE) return NULL;
@@ -1780,7 +1846,7 @@ void * APIENTRY binn_map_read_pair(void *ptr, int pos, int *pid, int *ptype, int
 
 /***************************************************************************/
 
-void * APIENTRY binn_object_read_pair(void *ptr, int pos, char *pkey, int *ptype, int *psize) {
+void * APIENTRY binn_object_read_pair(const void *ptr, int pos, char *pkey, int *ptype, int *psize) {
   binn value;
 
   if (binn_object_get_pair(ptr, pos, pkey, &value) == FALSE) return NULL;
@@ -1798,18 +1864,18 @@ void * APIENTRY binn_object_read_pair(void *ptr, int pos, char *pkey, int *ptype
 /*** SEQUENTIAL READ FUNCTIONS *********************************************/
 /***************************************************************************/
 
-BOOL APIENTRY binn_iter_init(binn_iter *iter, void *ptr, int expected_type) {
+BOOL APIENTRY binn_iter_init(binn_iter *iter, const void *ptr, int expected_type) {
   int  type, count, size=0, header_size;
 
   ptr = binn_ptr(ptr);
-  if ((ptr == 0) || (iter == 0)) return FALSE;
+  if (ptr == NULL || iter == NULL) return FALSE;
   memset(iter, 0, sizeof(binn_iter));
 
-  /*  check the header */
+  // check the header
   if (IsValidBinnHeader(ptr, &type, &count, &size, &header_size) == FALSE) return FALSE;
 
   if (type != expected_type) return FALSE;
-  /* if (count == 0) return FALSE;  -- should not be used */
+  //if (count == 0) return FALSE;  -- should not be used
 
   iter->plimit = (unsigned char *)ptr + size - 1;
   iter->pnext = (unsigned char *)ptr + header_size;
@@ -1825,7 +1891,7 @@ BOOL APIENTRY binn_iter_init(binn_iter *iter, void *ptr, int expected_type) {
 BOOL APIENTRY binn_list_next(binn_iter *iter, binn *value) {
   unsigned char *pnow;
 
-  if ((iter == 0) || (iter->pnext == 0) || (iter->pnext > iter->plimit) || (iter->current > iter->count) || (iter->type != BINN_LIST)) return FALSE;
+  if (iter == NULL || iter->pnext == NULL || iter->pnext > iter->plimit || iter->current > iter->count || iter->type != BINN_LIST) return FALSE;
 
   iter->current++;
   if (iter->current > iter->count) return FALSE;
@@ -1834,7 +1900,7 @@ BOOL APIENTRY binn_list_next(binn_iter *iter, binn *value) {
   iter->pnext = AdvanceDataPos(pnow, iter->plimit);
   if (iter->pnext != 0 && iter->pnext < pnow) return FALSE;
 
-  return GetValue(pnow, value);
+  return GetValue(pnow, iter->plimit, value);
 
 }
 
@@ -1845,7 +1911,7 @@ BINN_PRIVATE BOOL binn_read_next_pair(int expected_type, binn_iter *iter, int *p
   unsigned char *p, *key;
   unsigned short len;
 
-  if ((iter == 0) || (iter->pnext == 0) || (iter->pnext > iter->plimit) || (iter->current > iter->count) || (iter->type != expected_type)) return FALSE;
+  if (iter == NULL || iter->pnext == NULL || iter->pnext > iter->plimit || iter->current > iter->count || iter->type != expected_type) return FALSE;
 
   iter->current++;
   if (iter->current > iter->count) return FALSE;
@@ -1874,7 +1940,7 @@ BINN_PRIVATE BOOL binn_read_next_pair(int expected_type, binn_iter *iter, int *p
   iter->pnext = AdvanceDataPos(p, iter->plimit);
   if (iter->pnext != 0 && iter->pnext < p) return FALSE;
 
-  return GetValue(p, value);
+  return GetValue(p, iter->plimit, value);
 
 }
 
@@ -2074,14 +2140,14 @@ BINN_PRIVATE BOOL GetWriteConvertedData(int *ptype, void **ppvalue, int *psize) 
 #ifdef BINN_EXTENDED
     case BINN_SINGLE:
       f1 = **(float**)ppvalue;
-      d1 = f1;  /*  convert from float (32bits) to double (64bits) */
+      d1 = f1;  // convert from float (32bits) to double (64bits)
       type = BINN_SINGLE_STR;
       goto conv_double;
     case BINN_DOUBLE:
       d1 = **(double**)ppvalue;
       type = BINN_DOUBLE_STR;
 conv_double:
-      /*  the '%.17e' is more precise than the '%g' */
+      // the '%.17e' is more precise than the '%g'
       snprintf(pstr, 127, "%.17e", d1);
       *ppvalue = pstr;
       *ptype = type;
@@ -2094,13 +2160,13 @@ conv_double:
       snprintf(sptr, 127, "%E", **ppvalue);
       *ppvalue = sptr;
       */
-      return TRUE;  /* ! temporary */
+      return TRUE;  //! temporary
       break;
 
     case BINN_DATE:
     case BINN_DATETIME:
     case BINN_TIME:
-      return TRUE;  /* ! temporary */
+      return TRUE;  //! temporary
       break;
 
     case BINN_BOOL:
@@ -2140,9 +2206,9 @@ BINN_PRIVATE int type_family(int type)  {
 
     case BINN_FLOAT32:
     case BINN_FLOAT64:
-    /* case BINN_SINGLE: */
+    //case BINN_SINGLE:
     case BINN_SINGLE_STR:
-    /* case BINN_DOUBLE: */
+    //case BINN_DOUBLE:
     case BINN_DOUBLE_STR:
       return BINN_FAMILY_FLOAT;
 
@@ -2175,7 +2241,7 @@ BINN_PRIVATE int type_family(int type)  {
       return BINN_FAMILY_NULL;
 
     default:
-      /*  if it wasn't found */
+      // if it wasn't found
       return BINN_FAMILY_NONE;
   }
 
@@ -2206,7 +2272,7 @@ BINN_PRIVATE int int_type(int type)  {
 
 /*************************************************************************************/
 
-BINN_PRIVATE BOOL copy_raw_value(void *psource, void *pdest, int data_store) {
+BINN_PRIVATE BOOL copy_raw_value(const void *psource, void *pdest, int data_store) {
 
   switch (data_store) {
   case BINN_STORAGE_NOBYTES:
@@ -2238,7 +2304,7 @@ BINN_PRIVATE BOOL copy_raw_value(void *psource, void *pdest, int data_store) {
 
 /*************************************************************************************/
 
-BINN_PRIVATE BOOL copy_int_value(void *psource, void *pdest, int source_type, int dest_type) {
+BINN_PRIVATE BOOL copy_int_value(const void *psource, void *pdest, int source_type, int dest_type) {
   uint64 vuint64 = 0; int64 vint64 = 0;
 
   switch (source_type) {
@@ -2273,12 +2339,12 @@ BINN_PRIVATE BOOL copy_int_value(void *psource, void *pdest, int source_type, in
   }
 
 
-  /*  copy from int64 to uint64, if possible */
+  // copy from int64 to uint64, if possible
 
-  if ((int_type(source_type) == BINN_UNSIGNED_INT) && (int_type(dest_type) == BINN_SIGNED_INT)) {
+  if (int_type(source_type) == BINN_UNSIGNED_INT && int_type(dest_type) == BINN_SIGNED_INT) {
     if (vuint64 > INT64_MAX) return FALSE;
     vint64 = vuint64;
-  } else if ((int_type(source_type) == BINN_SIGNED_INT) && (int_type(dest_type) == BINN_UNSIGNED_INT)) {
+  } else if (int_type(source_type) == BINN_SIGNED_INT && int_type(dest_type) == BINN_UNSIGNED_INT) {
     if (vint64 < 0) return FALSE;
     vuint64 = vint64;
   }
@@ -2286,15 +2352,15 @@ BINN_PRIVATE BOOL copy_int_value(void *psource, void *pdest, int source_type, in
 
   switch (dest_type) {
   case BINN_INT8:
-    if ((vint64 < INT8_MIN) || (vint64 > INT8_MAX)) return FALSE;
+    if (vint64 < INT8_MIN || vint64 > INT8_MAX) return FALSE;
     *(signed char *)pdest = (signed char) vint64;
     break;
   case BINN_INT16:
-    if ((vint64 < INT16_MIN) || (vint64 > INT16_MAX)) return FALSE;
+    if (vint64 < INT16_MIN || vint64 > INT16_MAX) return FALSE;
     *(short *)pdest = (short) vint64;
     break;
   case BINN_INT32:
-    if ((vint64 < INT32_MIN) || (vint64 > INT32_MAX)) return FALSE;
+    if (vint64 < INT32_MIN || vint64 > INT32_MAX) return FALSE;
     *(int *)pdest = (int) vint64;
     break;
   case BINN_INT64:
@@ -2327,7 +2393,7 @@ BINN_PRIVATE BOOL copy_int_value(void *psource, void *pdest, int source_type, in
 
 /*************************************************************************************/
 
-BINN_PRIVATE BOOL copy_float_value(void *psource, void *pdest, int source_type) {
+BINN_PRIVATE BOOL copy_float_value(const void *psource, void *pdest, int source_type, int dest_type) {
 
   switch (source_type) {
   case BINN_FLOAT32:
@@ -2346,27 +2412,27 @@ BINN_PRIVATE BOOL copy_float_value(void *psource, void *pdest, int source_type) 
 
 /*************************************************************************************/
 
-BINN_PRIVATE void zero_value(void *pvalue, int type) {
-  /* int size=0; */
+BINN_PRIVATE void zero_value(const void *pvalue, int type) {
+  //int size=0;
 
   switch (binn_get_read_storage(type)) {
   case BINN_STORAGE_NOBYTES:
     break;
   case BINN_STORAGE_BYTE:
     *((char *) pvalue) = 0;
-    /* size=1; */
+    //size=1;
     break;
   case BINN_STORAGE_WORD:
     *((short *) pvalue) = 0;
-    /* size=2; */
+    //size=2;
     break;
   case BINN_STORAGE_DWORD:
     *((int *) pvalue) = 0;
-    /* size=4; */
+    //size=4;
     break;
   case BINN_STORAGE_QWORD:
     *((uint64 *) pvalue) = 0;
-    /* size=8; */
+    //size=8;
     break;
   case BINN_STORAGE_BLOB:
   case BINN_STORAGE_STRING:
@@ -2375,7 +2441,7 @@ BINN_PRIVATE void zero_value(void *pvalue, int type) {
     break;
   }
 
-  /* if (size>0) memset(pvalue, 0, size); */
+  //if (size>0) memset(pvalue, 0, size);
 
 }
 
@@ -2385,10 +2451,10 @@ BINN_PRIVATE BOOL copy_value(void *psource, void *pdest, int source_type, int de
 
   if (type_family(source_type) != type_family(dest_type)) return FALSE;
 
-  if ((type_family(source_type) == BINN_FAMILY_INT) && (source_type != dest_type)) {
+  if (type_family(source_type) == BINN_FAMILY_INT && source_type != dest_type) {
     return copy_int_value(psource, pdest, source_type, dest_type);
-  } else if ((type_family(source_type) == BINN_FAMILY_FLOAT) && (source_type != dest_type)) {
-    return copy_float_value(psource, pdest, source_type);
+  } else if (type_family(source_type) == BINN_FAMILY_FLOAT && source_type != dest_type) {
+    return copy_float_value(psource, pdest, source_type, dest_type);
   } else {
     return copy_raw_value(psource, pdest, data_store);
   }
@@ -2429,7 +2495,7 @@ BOOL APIENTRY binn_object_set(binn *obj, const char *key, int type, void *pvalue
 
 /*************************************************************************************/
 
-/*  this function is used by the wrappers */
+// this function is used by the wrappers
 BOOL APIENTRY binn_add_value(binn *item, int binn_type, int id, char *name, int type, void *pvalue, int size) {
 
   switch (binn_type) {
@@ -2483,7 +2549,7 @@ BOOL APIENTRY binn_object_set_new(binn *obj, const char *key, binn *value) {
 /*** READ FUNCTIONS ******************************************************************/
 /*************************************************************************************/
 
-binn * APIENTRY binn_list_value(void *ptr, int pos) {
+binn * APIENTRY binn_list_value(const void *ptr, int pos) {
   binn *value;
 
   value = (binn *) binn_malloc(sizeof(binn));
@@ -2500,7 +2566,7 @@ binn * APIENTRY binn_list_value(void *ptr, int pos) {
 
 /*************************************************************************************/
 
-binn * APIENTRY binn_map_value(void *ptr, int id) {
+binn * APIENTRY binn_map_value(const void *ptr, int id) {
   binn *value;
 
   value = (binn *) binn_malloc(sizeof(binn));
@@ -2517,7 +2583,7 @@ binn * APIENTRY binn_map_value(void *ptr, int id) {
 
 /*************************************************************************************/
 
-binn * APIENTRY binn_object_value(void *ptr, const char *key) {
+binn * APIENTRY binn_object_value(const void *ptr, const char *key) {
   binn *value;
 
   value = (binn *) binn_malloc(sizeof(binn));
@@ -2535,7 +2601,7 @@ binn * APIENTRY binn_object_value(void *ptr, const char *key) {
 /***************************************************************************/
 /***************************************************************************/
 
-void * APIENTRY binn_list_read(void *list, int pos, int *ptype, int *psize) {
+void * APIENTRY binn_list_read(const void *list, int pos, int *ptype, int *psize) {
   binn value;
 
   if (binn_list_get_value(list, pos, &value) == FALSE) return NULL;
@@ -2551,7 +2617,7 @@ void * APIENTRY binn_list_read(void *list, int pos, int *ptype, int *psize) {
 
 /***************************************************************************/
 
-void * APIENTRY binn_map_read(void *map, int id, int *ptype, int *psize) {
+void * APIENTRY binn_map_read(const void *map, int id, int *ptype, int *psize) {
   binn value;
 
   if (binn_map_get_value(map, id, &value) == FALSE) return NULL;
@@ -2567,7 +2633,7 @@ void * APIENTRY binn_map_read(void *map, int id, int *ptype, int *psize) {
 
 /***************************************************************************/
 
-void * APIENTRY binn_object_read(void *obj, const char *key, int *ptype, int *psize) {
+void * APIENTRY binn_object_read(const void *obj, const char *key, int *ptype, int *psize) {
   binn value;
 
   if (binn_object_get_value(obj, key, &value) == FALSE) return NULL;
@@ -2584,12 +2650,12 @@ void * APIENTRY binn_object_read(void *obj, const char *key, int *ptype, int *ps
 /***************************************************************************/
 /***************************************************************************/
 
-BOOL APIENTRY binn_list_get(void *ptr, int pos, int type, void *pvalue, int *psize) {
+BOOL APIENTRY binn_list_get(const void *ptr, int pos, int type, void *pvalue, int *psize) {
   binn value;
   int storage_type;
 
   storage_type = binn_get_read_storage(type);
-  if ((storage_type != BINN_STORAGE_NOBYTES) && (pvalue == NULL)) return FALSE;
+  if (storage_type != BINN_STORAGE_NOBYTES && pvalue == NULL) return FALSE;
 
   zero_value(pvalue, type);
 
@@ -2605,12 +2671,12 @@ BOOL APIENTRY binn_list_get(void *ptr, int pos, int type, void *pvalue, int *psi
 
 /***************************************************************************/
 
-BOOL APIENTRY binn_map_get(void *ptr, int id, int type, void *pvalue, int *psize) {
+BOOL APIENTRY binn_map_get(const void *ptr, int id, int type, void *pvalue, int *psize) {
   binn value;
   int storage_type;
 
   storage_type = binn_get_read_storage(type);
-  if ((storage_type != BINN_STORAGE_NOBYTES) && (pvalue == NULL)) return FALSE;
+  if (storage_type != BINN_STORAGE_NOBYTES && pvalue == NULL) return FALSE;
 
   zero_value(pvalue, type);
 
@@ -2626,14 +2692,14 @@ BOOL APIENTRY binn_map_get(void *ptr, int id, int type, void *pvalue, int *psize
 
 /***************************************************************************/
 
-/*    if (binn_object_get(obj, "multiplier", BINN_INT32, &multiplier, NULL) == FALSE) xxx; */
+//   if (binn_object_get(obj, "multiplier", BINN_INT32, &multiplier, NULL) == FALSE) xxx;
 
-BOOL APIENTRY binn_object_get(void *ptr, const char *key, int type, void *pvalue, int *psize) {
+BOOL APIENTRY binn_object_get(const void *ptr, const char *key, int type, void *pvalue, int *psize) {
   binn value;
   int storage_type;
 
   storage_type = binn_get_read_storage(type);
-  if ((storage_type != BINN_STORAGE_NOBYTES) && (pvalue == NULL)) return FALSE;
+  if (storage_type != BINN_STORAGE_NOBYTES && pvalue == NULL) return FALSE;
 
   zero_value(pvalue, type);
 
@@ -2650,14 +2716,14 @@ BOOL APIENTRY binn_object_get(void *ptr, const char *key, int type, void *pvalue
 /***************************************************************************/
 /***************************************************************************/
 
-/*  these functions below may not be implemented as inline functions, because */
-/*  they use a lot of space, even for the variable. so they will be exported. */
+// these functions below may not be implemented as inline functions, because
+// they use a lot of space, even for the variable. so they will be exported.
 
-/*  but what about using as static? */
-/*     is there any problem with wrappers? can these wrappers implement these functions using the header? */
-/*     if as static, will they be present even on modules that don't use the functions? */
+// but what about using as static?
+//    is there any problem with wrappers? can these wrappers implement these functions using the header?
+//    if as static, will they be present even on modules that don't use the functions?
 
-signed char APIENTRY binn_list_int8(void *list, int pos) {
+signed char APIENTRY binn_list_int8(const void *list, int pos) {
   signed char value;
 
   binn_list_get(list, pos, BINN_INT8, &value, NULL);
@@ -2665,7 +2731,7 @@ signed char APIENTRY binn_list_int8(void *list, int pos) {
   return value;
 }
 
-short APIENTRY binn_list_int16(void *list, int pos) {
+short APIENTRY binn_list_int16(const void *list, int pos) {
   short value;
 
   binn_list_get(list, pos, BINN_INT16, &value, NULL);
@@ -2673,7 +2739,7 @@ short APIENTRY binn_list_int16(void *list, int pos) {
   return value;
 }
 
-int APIENTRY binn_list_int32(void *list, int pos) {
+int APIENTRY binn_list_int32(const void *list, int pos) {
   int value;
 
   binn_list_get(list, pos, BINN_INT32, &value, NULL);
@@ -2681,7 +2747,7 @@ int APIENTRY binn_list_int32(void *list, int pos) {
   return value;
 }
 
-int64 APIENTRY binn_list_int64(void *list, int pos) {
+int64 APIENTRY binn_list_int64(const void *list, int pos) {
   int64 value;
 
   binn_list_get(list, pos, BINN_INT64, &value, NULL);
@@ -2689,7 +2755,7 @@ int64 APIENTRY binn_list_int64(void *list, int pos) {
   return value;
 }
 
-unsigned char APIENTRY binn_list_uint8(void *list, int pos) {
+unsigned char APIENTRY binn_list_uint8(const void *list, int pos) {
   unsigned char value;
 
   binn_list_get(list, pos, BINN_UINT8, &value, NULL);
@@ -2697,7 +2763,7 @@ unsigned char APIENTRY binn_list_uint8(void *list, int pos) {
   return value;
 }
 
-unsigned short APIENTRY binn_list_uint16(void *list, int pos) {
+unsigned short APIENTRY binn_list_uint16(const void *list, int pos) {
   unsigned short value;
 
   binn_list_get(list, pos, BINN_UINT16, &value, NULL);
@@ -2705,7 +2771,7 @@ unsigned short APIENTRY binn_list_uint16(void *list, int pos) {
   return value;
 }
 
-unsigned int APIENTRY binn_list_uint32(void *list, int pos) {
+unsigned int APIENTRY binn_list_uint32(const void *list, int pos) {
   unsigned int value;
 
   binn_list_get(list, pos, BINN_UINT32, &value, NULL);
@@ -2713,7 +2779,7 @@ unsigned int APIENTRY binn_list_uint32(void *list, int pos) {
   return value;
 }
 
-uint64 APIENTRY binn_list_uint64(void *list, int pos) {
+uint64 APIENTRY binn_list_uint64(const void *list, int pos) {
   uint64 value;
 
   binn_list_get(list, pos, BINN_UINT64, &value, NULL);
@@ -2721,7 +2787,7 @@ uint64 APIENTRY binn_list_uint64(void *list, int pos) {
   return value;
 }
 
-float APIENTRY binn_list_float(void *list, int pos) {
+float APIENTRY binn_list_float(const void *list, int pos) {
   float value;
 
   binn_list_get(list, pos, BINN_FLOAT32, &value, NULL);
@@ -2729,7 +2795,7 @@ float APIENTRY binn_list_float(void *list, int pos) {
   return value;
 }
 
-double APIENTRY binn_list_double(void *list, int pos) {
+double APIENTRY binn_list_double(const void *list, int pos) {
   double value;
 
   binn_list_get(list, pos, BINN_FLOAT64, &value, NULL);
@@ -2737,21 +2803,21 @@ double APIENTRY binn_list_double(void *list, int pos) {
   return value;
 }
 
-BOOL APIENTRY binn_list_bool(void *list, int pos) {
-  BOOL value;
+BOOL APIENTRY binn_list_bool(const void *list, int pos) {
+  BOOL value = TRUE;
 
   binn_list_get(list, pos, BINN_BOOL, &value, NULL);
 
   return value;
 }
 
-BOOL APIENTRY binn_list_null(void *list, int pos) {
+BOOL APIENTRY binn_list_null(const void *list, int pos) {
 
   return binn_list_get(list, pos, BINN_NULL, NULL, NULL);
 
 }
 
-char * APIENTRY binn_list_str(void *list, int pos) {
+char * APIENTRY binn_list_str(const void *list, int pos) {
   char *value;
 
   binn_list_get(list, pos, BINN_STRING, &value, NULL);
@@ -2759,7 +2825,7 @@ char * APIENTRY binn_list_str(void *list, int pos) {
   return value;
 }
 
-void * APIENTRY binn_list_blob(void *list, int pos, int *psize) {
+void * APIENTRY binn_list_blob(const void *list, int pos, int *psize) {
   void *value;
 
   binn_list_get(list, pos, BINN_BLOB, &value, psize);
@@ -2767,7 +2833,7 @@ void * APIENTRY binn_list_blob(void *list, int pos, int *psize) {
   return value;
 }
 
-void * APIENTRY binn_list_list(void *list, int pos) {
+void * APIENTRY binn_list_list(const void *list, int pos) {
   void *value;
 
   binn_list_get(list, pos, BINN_LIST, &value, NULL);
@@ -2775,7 +2841,7 @@ void * APIENTRY binn_list_list(void *list, int pos) {
   return value;
 }
 
-void * APIENTRY binn_list_map(void *list, int pos) {
+void * APIENTRY binn_list_map(const void *list, int pos) {
   void *value;
 
   binn_list_get(list, pos, BINN_MAP, &value, NULL);
@@ -2783,7 +2849,7 @@ void * APIENTRY binn_list_map(void *list, int pos) {
   return value;
 }
 
-void * APIENTRY binn_list_object(void *list, int pos) {
+void * APIENTRY binn_list_object(const void *list, int pos) {
   void *value;
 
   binn_list_get(list, pos, BINN_OBJECT, &value, NULL);
@@ -2793,7 +2859,7 @@ void * APIENTRY binn_list_object(void *list, int pos) {
 
 /***************************************************************************/
 
-signed char APIENTRY binn_map_int8(void *map, int id) {
+signed char APIENTRY binn_map_int8(const void *map, int id) {
   signed char value;
 
   binn_map_get(map, id, BINN_INT8, &value, NULL);
@@ -2801,7 +2867,7 @@ signed char APIENTRY binn_map_int8(void *map, int id) {
   return value;
 }
 
-short APIENTRY binn_map_int16(void *map, int id) {
+short APIENTRY binn_map_int16(const void *map, int id) {
   short value;
 
   binn_map_get(map, id, BINN_INT16, &value, NULL);
@@ -2809,7 +2875,7 @@ short APIENTRY binn_map_int16(void *map, int id) {
   return value;
 }
 
-int APIENTRY binn_map_int32(void *map, int id) {
+int APIENTRY binn_map_int32(const void *map, int id) {
   int value;
 
   binn_map_get(map, id, BINN_INT32, &value, NULL);
@@ -2817,7 +2883,7 @@ int APIENTRY binn_map_int32(void *map, int id) {
   return value;
 }
 
-int64 APIENTRY binn_map_int64(void *map, int id) {
+int64 APIENTRY binn_map_int64(const void *map, int id) {
   int64 value;
 
   binn_map_get(map, id, BINN_INT64, &value, NULL);
@@ -2825,7 +2891,7 @@ int64 APIENTRY binn_map_int64(void *map, int id) {
   return value;
 }
 
-unsigned char APIENTRY binn_map_uint8(void *map, int id) {
+unsigned char APIENTRY binn_map_uint8(const void *map, int id) {
   unsigned char value;
 
   binn_map_get(map, id, BINN_UINT8, &value, NULL);
@@ -2833,7 +2899,7 @@ unsigned char APIENTRY binn_map_uint8(void *map, int id) {
   return value;
 }
 
-unsigned short APIENTRY binn_map_uint16(void *map, int id) {
+unsigned short APIENTRY binn_map_uint16(const void *map, int id) {
   unsigned short value;
 
   binn_map_get(map, id, BINN_UINT16, &value, NULL);
@@ -2841,7 +2907,7 @@ unsigned short APIENTRY binn_map_uint16(void *map, int id) {
   return value;
 }
 
-unsigned int APIENTRY binn_map_uint32(void *map, int id) {
+unsigned int APIENTRY binn_map_uint32(const void *map, int id) {
   unsigned int value;
 
   binn_map_get(map, id, BINN_UINT32, &value, NULL);
@@ -2849,7 +2915,7 @@ unsigned int APIENTRY binn_map_uint32(void *map, int id) {
   return value;
 }
 
-uint64 APIENTRY binn_map_uint64(void *map, int id) {
+uint64 APIENTRY binn_map_uint64(const void *map, int id) {
   uint64 value;
 
   binn_map_get(map, id, BINN_UINT64, &value, NULL);
@@ -2857,7 +2923,7 @@ uint64 APIENTRY binn_map_uint64(void *map, int id) {
   return value;
 }
 
-float APIENTRY binn_map_float(void *map, int id) {
+float APIENTRY binn_map_float(const void *map, int id) {
   float value;
 
   binn_map_get(map, id, BINN_FLOAT32, &value, NULL);
@@ -2865,7 +2931,7 @@ float APIENTRY binn_map_float(void *map, int id) {
   return value;
 }
 
-double APIENTRY binn_map_double(void *map, int id) {
+double APIENTRY binn_map_double(const void *map, int id) {
   double value;
 
   binn_map_get(map, id, BINN_FLOAT64, &value, NULL);
@@ -2873,21 +2939,21 @@ double APIENTRY binn_map_double(void *map, int id) {
   return value;
 }
 
-BOOL APIENTRY binn_map_bool(void *map, int id) {
-  BOOL value;
+BOOL APIENTRY binn_map_bool(const void *map, int id) {
+  BOOL value = TRUE;
 
   binn_map_get(map, id, BINN_BOOL, &value, NULL);
 
   return value;
 }
 
-BOOL APIENTRY binn_map_null(void *map, int id) {
+BOOL APIENTRY binn_map_null(const void *map, int id) {
 
   return binn_map_get(map, id, BINN_NULL, NULL, NULL);
 
 }
 
-char * APIENTRY binn_map_str(void *map, int id) {
+char * APIENTRY binn_map_str(const void *map, int id) {
   char *value;
 
   binn_map_get(map, id, BINN_STRING, &value, NULL);
@@ -2895,7 +2961,7 @@ char * APIENTRY binn_map_str(void *map, int id) {
   return value;
 }
 
-void * APIENTRY binn_map_blob(void *map, int id, int *psize) {
+void * APIENTRY binn_map_blob(const void *map, int id, int *psize) {
   void *value;
 
   binn_map_get(map, id, BINN_BLOB, &value, psize);
@@ -2903,7 +2969,7 @@ void * APIENTRY binn_map_blob(void *map, int id, int *psize) {
   return value;
 }
 
-void * APIENTRY binn_map_list(void *map, int id) {
+void * APIENTRY binn_map_list(const void *map, int id) {
   void *value;
 
   binn_map_get(map, id, BINN_LIST, &value, NULL);
@@ -2911,7 +2977,7 @@ void * APIENTRY binn_map_list(void *map, int id) {
   return value;
 }
 
-void * APIENTRY binn_map_map(void *map, int id) {
+void * APIENTRY binn_map_map(const void *map, int id) {
   void *value;
 
   binn_map_get(map, id, BINN_MAP, &value, NULL);
@@ -2919,7 +2985,7 @@ void * APIENTRY binn_map_map(void *map, int id) {
   return value;
 }
 
-void * APIENTRY binn_map_object(void *map, int id) {
+void * APIENTRY binn_map_object(const void *map, int id) {
   void *value;
 
   binn_map_get(map, id, BINN_OBJECT, &value, NULL);
@@ -2929,7 +2995,7 @@ void * APIENTRY binn_map_object(void *map, int id) {
 
 /***************************************************************************/
 
-signed char APIENTRY binn_object_int8(void *obj, const char *key) {
+signed char APIENTRY binn_object_int8(const void *obj, const char *key) {
   signed char value;
 
   binn_object_get(obj, key, BINN_INT8, &value, NULL);
@@ -2937,7 +3003,7 @@ signed char APIENTRY binn_object_int8(void *obj, const char *key) {
   return value;
 }
 
-short APIENTRY binn_object_int16(void *obj, const char *key) {
+short APIENTRY binn_object_int16(const void *obj, const char *key) {
   short value;
 
   binn_object_get(obj, key, BINN_INT16, &value, NULL);
@@ -2945,7 +3011,7 @@ short APIENTRY binn_object_int16(void *obj, const char *key) {
   return value;
 }
 
-int APIENTRY binn_object_int32(void *obj, const char *key) {
+int APIENTRY binn_object_int32(const void *obj, const char *key) {
   int value;
 
   binn_object_get(obj, key, BINN_INT32, &value, NULL);
@@ -2953,7 +3019,7 @@ int APIENTRY binn_object_int32(void *obj, const char *key) {
   return value;
 }
 
-int64 APIENTRY binn_object_int64(void *obj, const char *key) {
+int64 APIENTRY binn_object_int64(const void *obj, const char *key) {
   int64 value;
 
   binn_object_get(obj, key, BINN_INT64, &value, NULL);
@@ -2961,7 +3027,7 @@ int64 APIENTRY binn_object_int64(void *obj, const char *key) {
   return value;
 }
 
-unsigned char APIENTRY binn_object_uint8(void *obj, const char *key) {
+unsigned char APIENTRY binn_object_uint8(const void *obj, const char *key) {
   unsigned char value;
 
   binn_object_get(obj, key, BINN_UINT8, &value, NULL);
@@ -2969,7 +3035,7 @@ unsigned char APIENTRY binn_object_uint8(void *obj, const char *key) {
   return value;
 }
 
-unsigned short APIENTRY binn_object_uint16(void *obj, const char *key) {
+unsigned short APIENTRY binn_object_uint16(const void *obj, const char *key) {
   unsigned short value;
 
   binn_object_get(obj, key, BINN_UINT16, &value, NULL);
@@ -2977,7 +3043,7 @@ unsigned short APIENTRY binn_object_uint16(void *obj, const char *key) {
   return value;
 }
 
-unsigned int APIENTRY binn_object_uint32(void *obj, const char *key) {
+unsigned int APIENTRY binn_object_uint32(const void *obj, const char *key) {
   unsigned int value;
 
   binn_object_get(obj, key, BINN_UINT32, &value, NULL);
@@ -2985,7 +3051,7 @@ unsigned int APIENTRY binn_object_uint32(void *obj, const char *key) {
   return value;
 }
 
-uint64 APIENTRY binn_object_uint64(void *obj, const char *key) {
+uint64 APIENTRY binn_object_uint64(const void *obj, const char *key) {
   uint64 value;
 
   binn_object_get(obj, key, BINN_UINT64, &value, NULL);
@@ -2993,7 +3059,7 @@ uint64 APIENTRY binn_object_uint64(void *obj, const char *key) {
   return value;
 }
 
-float APIENTRY binn_object_float(void *obj, const char *key) {
+float APIENTRY binn_object_float(const void *obj, const char *key) {
   float value;
 
   binn_object_get(obj, key, BINN_FLOAT32, &value, NULL);
@@ -3001,7 +3067,7 @@ float APIENTRY binn_object_float(void *obj, const char *key) {
   return value;
 }
 
-double APIENTRY binn_object_double(void *obj, const char *key) {
+double APIENTRY binn_object_double(const void *obj, const char *key) {
   double value;
 
   binn_object_get(obj, key, BINN_FLOAT64, &value, NULL);
@@ -3009,21 +3075,21 @@ double APIENTRY binn_object_double(void *obj, const char *key) {
   return value;
 }
 
-BOOL APIENTRY binn_object_bool(void *obj, const char *key) {
-  BOOL value;
+BOOL APIENTRY binn_object_bool(const void *obj, const char *key) {
+  BOOL value = TRUE;
 
   binn_object_get(obj, key, BINN_BOOL, &value, NULL);
 
   return value;
 }
 
-BOOL APIENTRY binn_object_null(void *obj, const char *key) {
+BOOL APIENTRY binn_object_null(const void *obj, const char *key) {
 
   return binn_object_get(obj, key, BINN_NULL, NULL, NULL);
 
 }
 
-char * APIENTRY binn_object_str(void *obj, const char *key) {
+char * APIENTRY binn_object_str(const void *obj, const char *key) {
   char *value;
 
   binn_object_get(obj, key, BINN_STRING, &value, NULL);
@@ -3031,7 +3097,7 @@ char * APIENTRY binn_object_str(void *obj, const char *key) {
   return value;
 }
 
-void * APIENTRY binn_object_blob(void *obj, const char *key, int *psize) {
+void * APIENTRY binn_object_blob(const void *obj, const char *key, int *psize) {
   void *value;
 
   binn_object_get(obj, key, BINN_BLOB, &value, psize);
@@ -3039,7 +3105,7 @@ void * APIENTRY binn_object_blob(void *obj, const char *key, int *psize) {
   return value;
 }
 
-void * APIENTRY binn_object_list(void *obj, const char *key) {
+void * APIENTRY binn_object_list(const void *obj, const char *key) {
   void *value;
 
   binn_object_get(obj, key, BINN_LIST, &value, NULL);
@@ -3047,7 +3113,7 @@ void * APIENTRY binn_object_list(void *obj, const char *key) {
   return value;
 }
 
-void * APIENTRY binn_object_map(void *obj, const char *key) {
+void * APIENTRY binn_object_map(const void *obj, const char *key) {
   void *value;
 
   binn_object_get(obj, key, BINN_MAP, &value, NULL);
@@ -3055,7 +3121,7 @@ void * APIENTRY binn_object_map(void *obj, const char *key) {
   return value;
 }
 
-void * APIENTRY binn_object_object(void *obj, const char *key) {
+void * APIENTRY binn_object_object(const void *obj, const char *key) {
   void *value;
 
   binn_object_get(obj, key, BINN_OBJECT, &value, NULL);
@@ -3073,7 +3139,7 @@ BINN_PRIVATE binn * binn_alloc_item() {
     memset(item, 0, sizeof(binn));
     item->header = BINN_MAGIC;
     item->allocated = TRUE;
-    /* item->writable = FALSE;  -- already zeroed */
+    //item->writable = FALSE;  -- already zeroed
   }
   return item;
 }
@@ -3193,7 +3259,7 @@ BINN_PRIVATE BOOL is_integer(char *p) {
   retval = TRUE;
 
   for (; *p; p++) {
-    if ( (*p < '0') || (*p > '9') ) {
+    if ( (*p < '0' || *p > '9') ) {
       retval = FALSE;
     }
   }
@@ -3213,9 +3279,9 @@ BINN_PRIVATE BOOL is_float(char *p) {
   retval = TRUE;
 
   for (; *p; p++) {
-    if ((*p == '.') || (*p == ',')) {
+    if (*p == '.' || *p == ',') {
       if (!number_found) retval = FALSE;
-    } else if ( (*p >= '0') && (*p <= '9') ) {
+    } else if ( *p >= '0' && *p <= '9' ) {
       number_found = TRUE;
     } else {
       return FALSE;
@@ -3236,12 +3302,12 @@ BINN_PRIVATE BOOL is_bool_str(char *str, BOOL *pbool) {
   if (stricmp(str, "true") == 0) goto loc_true;
   if (stricmp(str, "yes") == 0) goto loc_true;
   if (stricmp(str, "on") == 0) goto loc_true;
-  /* if (stricmp(str, "1") == 0) goto loc_true; */
+  //if (stricmp(str, "1") == 0) goto loc_true;
 
   if (stricmp(str, "false") == 0) goto loc_false;
   if (stricmp(str, "no") == 0) goto loc_false;
   if (stricmp(str, "off") == 0) goto loc_false;
-  /* if (stricmp(str, "0") == 0) goto loc_false; */
+  //if (stricmp(str, "0") == 0) goto loc_false;
 
   if (is_integer(str)) {
     vint = atoi64(str);
@@ -3265,27 +3331,6 @@ loc_false:
 
 }
 
-/* these three functions are used to
- * suppress warnings about implicit conversions
- * in binn_get_int32 and binn_get_int64
- * CJR 2/9/2023
- */
-
-float
-binn_cvt_int2float (int value) {
-  return (float)value;
-}
-
-float
-binn_cvt_long2float (long int value) {
-  return (float)value;
-}
-
-float
-binn_cvt_long2dbl (long int value) {
-  return (long long int)value;
-}
-
 /*************************************************************************************/
 
 BOOL APIENTRY binn_get_int32(binn *value, int *pint) {
@@ -3298,11 +3343,11 @@ BOOL APIENTRY binn_get_int32(binn *value, int *pint) {
 
   switch (value->type) {
   case BINN_FLOAT:
-    if ((value->vfloat < binn_cvt_int2float(INT32_MIN)) || (value->vfloat > binn_cvt_int2float(INT32_MAX))) return FALSE;
+    if (value->vfloat < (float)INT32_MIN || value->vfloat > (float)INT32_MAX) return FALSE;
     *pint = roundval(value->vfloat);
     break;
   case BINN_DOUBLE:
-    if ((value->vdouble < INT32_MIN) || (value->vdouble > INT32_MAX)) return FALSE;
+    if (value->vdouble < (double)INT32_MIN || value->vdouble > (double)INT32_MAX) return FALSE;
     *pint = roundval(value->vdouble);
     break;
   case BINN_STRING:
@@ -3335,11 +3380,11 @@ BOOL APIENTRY binn_get_int64(binn *value, int64 *pint) {
 
   switch (value->type) {
   case BINN_FLOAT:
-    if ((value->vfloat < binn_cvt_long2float(INT64_MIN)) || (value->vfloat > binn_cvt_long2float(INT64_MAX))) return FALSE;
+    if (value->vfloat < (float)INT64_MIN || value->vfloat > (float)INT64_MAX) return FALSE;
     *pint = roundval(value->vfloat);
     break;
   case BINN_DOUBLE:
-    if ((value->vdouble < binn_cvt_long2dbl(INT64_MIN)) || (value->vdouble > binn_cvt_long2dbl(INT64_MAX))) return FALSE;
+    if (value->vdouble < (double)INT64_MIN || value->vdouble > (double)INT64_MAX) return FALSE;
     *pint = roundval(value->vdouble);
     break;
   case BINN_STRING:
@@ -3465,7 +3510,7 @@ char * APIENTRY binn_get_str(binn *value) {
 
 loc_convert_value:
 
-  /* value->vint64 = 0; */
+  //value->vint64 = 0;
   value->ptr = strdup(buf);
   if (value->ptr == NULL) return NULL;
   value->freefn = free;

--- a/binn.h
+++ b/binn.h
@@ -1,13 +1,12 @@
 
-/*  TO ENABLE INLINE FUNCTIONS: */
-/*    ON MSVC: enable the 'Inline Function Expansion' (/Ob2) compiler option, and maybe the */
-/*             'Whole Program Optimitazion' (/GL), that requires the */
-/*             'Link Time Code Generation' (/LTCG) linker option to be enabled too */
+// TO ENABLE INLINE FUNCTIONS:
+//   ON MSVC: enable the 'Inline Function Expansion' (/Ob2) compiler option, and maybe the
+//            'Whole Program Optimitazion' (/GL), that requires the
+//            'Link Time Code Generation' (/LTCG) linker option to be enabled too
 
 #ifndef BINN_H
 #define BINN_H
-#include <stddef.h>
-#include "config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -38,7 +37,7 @@ typedef int BOOL;
  #ifdef _WIN32
   #define APIENTRY __stdcall
  #else
-  /* #define APIENTRY __attribute__((stdcall)) */
+  //#define APIENTRY __attribute__((stdcall))
   #define APIENTRY 
  #endif
 #endif
@@ -55,7 +54,7 @@ typedef int BOOL;
   #define INLINE         __inline
   #define ALWAYS_INLINE  __forceinline
 #else
-  /*  you can change to 'extern inline' if using the gcc option -flto */
+  // you can change to 'extern inline' if using the gcc option -flto
   #define INLINE         static inline
   #define ALWAYS_INLINE  static inline __attribute__((always_inline))
 #endif
@@ -81,18 +80,18 @@ typedef int BOOL;
 #endif
 
 
-/*  BINN CONSTANTS  ---------------------------------------- */
+// BINN CONSTANTS  ----------------------------------------
 
 #define INVALID_BINN         0
 
-/*  Storage Data Types  ------------------------------------ */
+// Storage Data Types  ------------------------------------
 
 #define BINN_STORAGE_NOBYTES   0x00
-#define BINN_STORAGE_BYTE      0x20  /*   8 bits */
-#define BINN_STORAGE_WORD      0x40  /*  16 bits -- the endianess (byte order) is automatically corrected */
-#define BINN_STORAGE_DWORD     0x60  /*  32 bits -- the endianess (byte order) is automatically corrected */
-#define BINN_STORAGE_QWORD     0x80  /*  64 bits -- the endianess (byte order) is automatically corrected */
-#define BINN_STORAGE_STRING    0xA0  /*  Are stored with null termination */
+#define BINN_STORAGE_BYTE      0x20  //  8 bits
+#define BINN_STORAGE_WORD      0x40  // 16 bits -- the endianess (byte order) is automatically corrected
+#define BINN_STORAGE_DWORD     0x60  // 32 bits -- the endianess (byte order) is automatically corrected
+#define BINN_STORAGE_QWORD     0x80  // 64 bits -- the endianess (byte order) is automatically corrected
+#define BINN_STORAGE_STRING    0xA0  // Are stored with null termination
 #define BINN_STORAGE_BLOB      0xC0
 #define BINN_STORAGE_CONTAINER 0xE0
 #define BINN_STORAGE_VIRTUAL   0x80000
@@ -109,7 +108,7 @@ typedef int BOOL;
 #define BINN_MAX_VALUE_MASK    0xFFFFF
 
 
-/*  Data Formats  ------------------------------------------ */
+// Data Formats  ------------------------------------------
 
 #define BINN_LIST      0xE0
 #define BINN_MAP       0xE1
@@ -119,54 +118,54 @@ typedef int BOOL;
 #define BINN_TRUE      0x01
 #define BINN_FALSE     0x02
 
-#define BINN_UINT8     0x20  /*  (BYTE) (unsigned byte) Is the default format for the BYTE type */
-#define BINN_INT8      0x21  /*  (BYTE) (signed byte, from -128 to +127. The 0x80 is the sign bit, so the range in hex is from 0x80 [-128] to 0x7F [127], being 0x00 = 0 and 0xFF = -1) */
-#define BINN_UINT16    0x40  /*  (WORD) (unsigned integer) Is the default format for the WORD type */
-#define BINN_INT16     0x41  /*  (WORD) (signed integer) */
-#define BINN_UINT32    0x60  /*  (DWORD) (unsigned integer) Is the default format for the DWORD type */
-#define BINN_INT32     0x61  /*  (DWORD) (signed integer) */
-#define BINN_UINT64    0x80  /*  (QWORD) (unsigned integer) Is the default format for the QWORD type */
-#define BINN_INT64     0x81  /*  (QWORD) (signed integer) */
+#define BINN_UINT8     0x20  // (BYTE) (unsigned byte) Is the default format for the BYTE type
+#define BINN_INT8      0x21  // (BYTE) (signed byte, from -128 to +127. The 0x80 is the sign bit, so the range in hex is from 0x80 [-128] to 0x7F [127], being 0x00 = 0 and 0xFF = -1)
+#define BINN_UINT16    0x40  // (WORD) (unsigned integer) Is the default format for the WORD type
+#define BINN_INT16     0x41  // (WORD) (signed integer)
+#define BINN_UINT32    0x60  // (DWORD) (unsigned integer) Is the default format for the DWORD type
+#define BINN_INT32     0x61  // (DWORD) (signed integer)
+#define BINN_UINT64    0x80  // (QWORD) (unsigned integer) Is the default format for the QWORD type
+#define BINN_INT64     0x81  // (QWORD) (signed integer)
 
 #define BINN_SCHAR     BINN_INT8
 #define BINN_UCHAR     BINN_UINT8
 
-#define BINN_STRING    0xA0  /*  (STRING) Raw String */
-#define BINN_DATETIME  0xA1  /*  (STRING) iso8601 format -- YYYY-MM-DD HH:MM:SS */
-#define BINN_DATE      0xA2  /*  (STRING) iso8601 format -- YYYY-MM-DD */
-#define BINN_TIME      0xA3  /*  (STRING) iso8601 format -- HH:MM:SS */
-#define BINN_DECIMAL   0xA4  /*  (STRING) High precision number - used for generic decimal values and for those ones that cannot be represented in the float64 format. */
-#define BINN_CURRENCYSTR  0xA5  /*  (STRING) With currency unit/symbol - check for some iso standard format */
-#define BINN_SINGLE_STR   0xA6  /*  (STRING) Can be restored to float32 */
-#define BINN_DOUBLE_STR   0xA7  /*  (STRING) May be restored to float64 */
+#define BINN_STRING    0xA0  // (STRING) Raw String
+#define BINN_DATETIME  0xA1  // (STRING) iso8601 format -- YYYY-MM-DD HH:MM:SS
+#define BINN_DATE      0xA2  // (STRING) iso8601 format -- YYYY-MM-DD
+#define BINN_TIME      0xA3  // (STRING) iso8601 format -- HH:MM:SS
+#define BINN_DECIMAL   0xA4  // (STRING) High precision number - used for generic decimal values and for those ones that cannot be represented in the float64 format.
+#define BINN_CURRENCYSTR  0xA5  // (STRING) With currency unit/symbol - check for some iso standard format
+#define BINN_SINGLE_STR   0xA6  // (STRING) Can be restored to float32
+#define BINN_DOUBLE_STR   0xA7  // (STRING) May be restored to float64
 
-#define BINN_FLOAT32   0x62  /*  (DWORD)  */
-#define BINN_FLOAT64   0x82  /*  (QWORD)  */
+#define BINN_FLOAT32   0x62  // (DWORD) 
+#define BINN_FLOAT64   0x82  // (QWORD) 
 #define BINN_FLOAT     BINN_FLOAT32
 #define BINN_SINGLE    BINN_FLOAT32
 #define BINN_DOUBLE    BINN_FLOAT64
 
-#define BINN_CURRENCY  0x83  /*  (QWORD) */
+#define BINN_CURRENCY  0x83  // (QWORD)
 
-#define BINN_BLOB      0xC0  /*  (BLOB) Raw Blob */
+#define BINN_BLOB      0xC0  // (BLOB) Raw Blob
 
 
-/*  virtual types: */
+// virtual types:
 
-#define BINN_BOOL      0x80061  /*  (DWORD) The value may be 0 or 1 */
+#define BINN_BOOL      0x80061  // (DWORD) The value may be 0 or 1
 
 #ifdef BINN_EXTENDED
-/* #define BINN_SINGLE    0x800A1  // (STRING) Can be restored to float32 */
-/* #define BINN_DOUBLE    0x800A2  // (STRING) May be restored to float64 */
+//#define BINN_SINGLE    0x800A1  // (STRING) Can be restored to float32
+//#define BINN_DOUBLE    0x800A2  // (STRING) May be restored to float64
 #endif
 
-/* #define BINN_BINN      0x800E1  // (CONTAINER) */
-/* #define BINN_BINN_BUFFER  0x800C1  // (BLOB) user binn. it's not open by the parser */
+//#define BINN_BINN      0x800E1  // (CONTAINER)
+//#define BINN_BINN_BUFFER  0x800C1  // (BLOB) user binn. it's not open by the parser
 
 
-/*  extended content types: */
+// extended content types:
 
-/*  strings: */
+// strings:
 
 #define BINN_HTML      0xB001
 #define BINN_XML       0xB002
@@ -174,7 +173,7 @@ typedef int BOOL;
 #define BINN_JAVASCRIPT 0xB004
 #define BINN_CSS       0xB005
 
-/*  blobs: */
+// blobs:
 
 #define BINN_JPEG      0xD001
 #define BINN_GIF       0xD002
@@ -182,7 +181,7 @@ typedef int BOOL;
 #define BINN_BMP       0xD004
 
 
-/*  type families */
+// type families
 #define BINN_FAMILY_NONE   0x00
 #define BINN_FAMILY_NULL   0xf1
 #define BINN_FAMILY_INT    0xf2
@@ -192,7 +191,7 @@ typedef int BOOL;
 #define BINN_FAMILY_BOOL   0xf6
 #define BINN_FAMILY_BINN   0xf7
 
-/*  integer types related to signal */
+// integer types related to signal
 #define BINN_SIGNED_INT     11
 #define BINN_UNSIGNED_INT   22
 
@@ -202,27 +201,27 @@ typedef void (*binn_mem_free)(void*);
 #define BINN_TRANSIENT   ((binn_mem_free)-1)
 
 
-/*  --- BINN STRUCTURE -------------------------------------------------------------- */
+// --- BINN STRUCTURE --------------------------------------------------------------
 
 
 struct binn_struct {
-  int    header;     /*  this struct header holds the magic number (BINN_MAGIC) that identifies this memory block as a binn structure */
-  BOOL   allocated;  /*  the struct can be allocated using malloc_fn() or can be on the stack */
-  BOOL   writable;   /*  did it was create for writing? it can use the pbuf if not unified with ptr */
-  BOOL   dirty;      /*  the container header is not written to the buffer */
-  /*  */
-  void  *pbuf;       /*  use *ptr below? */
+  int    header;     // this struct header holds the magic number (BINN_MAGIC) that identifies this memory block as a binn structure
+  BOOL   allocated;  // the struct can be allocated using malloc_fn() or can be on the stack
+  BOOL   writable;   // did it was create for writing? it can use the pbuf if not unified with ptr
+  BOOL   dirty;      // the container header is not written to the buffer
+  //
+  void  *pbuf;       // use *ptr below?
   BOOL   pre_allocated;
   int    alloc_size;
   int    used_size;
-  /*  */
+  //
   int    type;
   void  *ptr;
   int    size;
   int    count;
-  /*  */
-  binn_mem_free freefn;  /*  used only when type == BINN_STRING or BINN_BLOB */
-  /*  */
+  //
+  binn_mem_free freefn;  // used only when type == BINN_STRING or BINN_BLOB
+  //
   union {
     signed char    vint8;
     signed short   vint16;
@@ -232,20 +231,20 @@ struct binn_struct {
     unsigned short vuint16;
     unsigned int   vuint32;
     uint64         vuint64;
-    /*  */
+    //
     signed char    vchar;
     unsigned char  vuchar;
     signed short   vshort;
     unsigned short vushort;
     signed int     vint;
     unsigned int   vuint;
-    /*  */
+    //
     float          vfloat;
     double         vdouble;
-    /*  */
+    //
     BOOL           vbool;
   };
-  /*  */
+  //
   BOOL   disable_int_compression;
 };
 
@@ -253,7 +252,7 @@ typedef struct binn_struct binn;
 
 
 
-/*  --- GENERAL FUNCTIONS  ---------------------------------------------------------- */
+// --- GENERAL FUNCTIONS  ----------------------------------------------------------
 
 char * APIENTRY binn_version();
 
@@ -268,22 +267,22 @@ int    APIENTRY binn_get_read_storage(int type);
 BOOL   APIENTRY binn_is_container(binn *item);
 
 
-/*  --- WRITE FUNCTIONS  ------------------------------------------------------------ */
+// --- WRITE FUNCTIONS  ------------------------------------------------------------
 
-/*  create a new binn allocating memory for the structure */
+// create a new binn allocating memory for the structure
 binn * APIENTRY binn_new(int type, int size, void *buffer);
 binn * APIENTRY binn_list();
 binn * APIENTRY binn_map();
 binn * APIENTRY binn_object();
 
-/*  create a new binn storing the structure on the stack */
+// create a new binn storing the structure on the stack
 BOOL APIENTRY binn_create(binn *item, int type, int size, void *buffer);
 BOOL APIENTRY binn_create_list(binn *list);
 BOOL APIENTRY binn_create_map(binn *map);
 BOOL APIENTRY binn_create_object(binn *object);
 
-/*  create a new binn as a copy from another */
-binn * APIENTRY binn_copy(void *old);
+// create a new binn as a copy from another
+binn * APIENTRY binn_copy(const void *old);
 
 
 BOOL APIENTRY binn_list_add_new(binn *list, binn *value);
@@ -291,20 +290,20 @@ BOOL APIENTRY binn_map_set_new(binn *map, int id, binn *value);
 BOOL APIENTRY binn_object_set_new(binn *obj, const char *key, binn *value);
 
 
-/*  extended interface */
+// extended interface
 
 BOOL   APIENTRY binn_list_add(binn *list, int type, void *pvalue, int size);
 BOOL   APIENTRY binn_map_set(binn *map, int id, int type, void *pvalue, int size);
 BOOL   APIENTRY binn_object_set(binn *obj, const char *key, int type, void *pvalue, int size);
 
 
-/*  release memory */
+// release memory
 
 void   APIENTRY binn_free(binn *item);
-void * APIENTRY binn_release(binn *item); /*  free the binn structure but keeps the binn buffer allocated, returning a pointer to it. use the free function to release the buffer later */
+void * APIENTRY binn_release(binn *item); // free the binn structure but keeps the binn buffer allocated, returning a pointer to it. use the free function to release the buffer later
 
 
-/*  --- CREATING VALUES --------------------------------------------------- */
+// --- CREATING VALUES ---------------------------------------------------
 
 binn * APIENTRY binn_value(int type, void *pvalue, int size, binn_mem_free freefn);
 
@@ -352,22 +351,22 @@ ALWAYS_INLINE binn * binn_blob(void *ptr, int size, binn_mem_free freefn) {
 }
 
 
-/*  --- READ FUNCTIONS  ------------------------------------------------------------- */
+// --- READ FUNCTIONS  -------------------------------------------------------------
 
-/*  these functions accept pointer to the binn structure and pointer to the binn buffer */
-void * APIENTRY binn_ptr(void *ptr);
-int    APIENTRY binn_size(void *ptr);
-int    APIENTRY binn_type(void *ptr);
-int    APIENTRY binn_count(void *ptr);
+// these functions accept pointer to the binn structure and pointer to the binn buffer
+void * APIENTRY binn_ptr(const void *ptr);
+int    APIENTRY binn_size(const void *ptr);
+int    APIENTRY binn_type(const void *ptr);
+int    APIENTRY binn_count(const void *ptr);
 
-BOOL   APIENTRY binn_is_valid(void *ptr, int *ptype, int *pcount, int *psize);
+BOOL   APIENTRY binn_is_valid(const void *ptr, int *ptype, int *pcount, int *psize);
 /* the function returns the values (type, count and size) and they don't need to be
    initialized. these values are read from the buffer. example:
 
    int type, count, size;
    result = binn_is_valid(ptr, &type, &count, &size);
 */
-BOOL   APIENTRY binn_is_valid_ex(void *ptr, int *ptype, int *pcount, int *psize);
+BOOL   APIENTRY binn_is_valid_ex(const void *ptr, int *ptype, int *pcount, int *psize);
 /* if some value is informed (type, count or size) then the function will check if 
    the value returned from the serialized data matches the informed value. otherwise
    the values must be initialized to zero. example:
@@ -376,117 +375,119 @@ BOOL   APIENTRY binn_is_valid_ex(void *ptr, int *ptype, int *pcount, int *psize)
    result = binn_is_valid_ex(ptr, &type, &count, &size);
 */
 
-BOOL   APIENTRY binn_is_struct(void *ptr);
+BOOL   APIENTRY binn_is_struct(const void *ptr);
 
 
-/*  Loading a binn buffer into a binn value - this is optional */
+// Loading a binn buffer into a binn value - this is optional
 
-BOOL   APIENTRY binn_load(void *data, binn *item);  /*  on stack */
-binn * APIENTRY binn_open(void *data);              /*  allocated */
-
-
-/*  easiest interface to use, but don't check if the value is there */
-
-signed char    APIENTRY binn_list_int8(void *list, int pos);
-short          APIENTRY binn_list_int16(void *list, int pos);
-int            APIENTRY binn_list_int32(void *list, int pos);
-int64          APIENTRY binn_list_int64(void *list, int pos);
-unsigned char  APIENTRY binn_list_uint8(void *list, int pos);
-unsigned short APIENTRY binn_list_uint16(void *list, int pos);
-unsigned int   APIENTRY binn_list_uint32(void *list, int pos);
-uint64         APIENTRY binn_list_uint64(void *list, int pos);
-float          APIENTRY binn_list_float(void *list, int pos);
-double         APIENTRY binn_list_double(void *list, int pos);
-BOOL           APIENTRY binn_list_bool(void *list, int pos);
-BOOL           APIENTRY binn_list_null(void *list, int pos);
-char *         APIENTRY binn_list_str(void *list, int pos);
-void *         APIENTRY binn_list_blob(void *list, int pos, int *psize);
-void *         APIENTRY binn_list_list(void *list, int pos);
-void *         APIENTRY binn_list_map(void *list, int pos);
-void *         APIENTRY binn_list_object(void *list, int pos);
-
-signed char    APIENTRY binn_map_int8(void *map, int id);
-short          APIENTRY binn_map_int16(void *map, int id);
-int            APIENTRY binn_map_int32(void *map, int id);
-int64          APIENTRY binn_map_int64(void *map, int id);
-unsigned char  APIENTRY binn_map_uint8(void *map, int id);
-unsigned short APIENTRY binn_map_uint16(void *map, int id);
-unsigned int   APIENTRY binn_map_uint32(void *map, int id);
-uint64         APIENTRY binn_map_uint64(void *map, int id);
-float          APIENTRY binn_map_float(void *map, int id);
-double         APIENTRY binn_map_double(void *map, int id);
-BOOL           APIENTRY binn_map_bool(void *map, int id);
-BOOL           APIENTRY binn_map_null(void *map, int id);
-char *         APIENTRY binn_map_str(void *map, int id);
-void *         APIENTRY binn_map_blob(void *map, int id, int *psize);
-void *         APIENTRY binn_map_list(void *map, int id);
-void *         APIENTRY binn_map_map(void *map, int id);
-void *         APIENTRY binn_map_object(void *map, int id);
-
-signed char    APIENTRY binn_object_int8(void *obj, const char *key);
-short          APIENTRY binn_object_int16(void *obj, const char *key);
-int            APIENTRY binn_object_int32(void *obj, const char *key);
-int64          APIENTRY binn_object_int64(void *obj, const char *key);
-unsigned char  APIENTRY binn_object_uint8(void *obj, const char *key);
-unsigned short APIENTRY binn_object_uint16(void *obj, const char *key);
-unsigned int   APIENTRY binn_object_uint32(void *obj, const char *key);
-uint64         APIENTRY binn_object_uint64(void *obj, const char *key);
-float          APIENTRY binn_object_float(void *obj, const char *key);
-double         APIENTRY binn_object_double(void *obj, const char *key);
-BOOL           APIENTRY binn_object_bool(void *obj, const char *key);
-BOOL           APIENTRY binn_object_null(void *obj, const char *key);
-char *         APIENTRY binn_object_str(void *obj, const char *key);
-void *         APIENTRY binn_object_blob(void *obj, const char *key, int *psize);
-void *         APIENTRY binn_object_list(void *obj, const char *key);
-void *         APIENTRY binn_object_map(void *obj, const char *key);
-void *         APIENTRY binn_object_object(void *obj, const char *key);
+binn * APIENTRY binn_open(const void *data);              // allocated - unsecure
+binn * APIENTRY binn_open_ex(const void *data, int size); // allocated - secure
+BOOL   APIENTRY binn_load(const void *data, binn *item);  // on stack - unsecure
+BOOL   APIENTRY binn_load_ex(const void *data, int size, binn *value); // secure
 
 
-/*  return a pointer to an allocated binn structure - must be released with the free() function or equivalent set in binn_set_alloc_functions() */
-binn * APIENTRY binn_list_value(void *list, int pos);
-binn * APIENTRY binn_map_value(void *map, int id);
-binn * APIENTRY binn_object_value(void *obj, const char *key);
+// easiest interface to use, but don't check if the value is there
 
-/*  read the value to a binn structure on the stack */
-BOOL APIENTRY binn_list_get_value(void* list, int pos, binn *value);
-BOOL APIENTRY binn_map_get_value(void* map, int id, binn *value);
-BOOL APIENTRY binn_object_get_value(void *obj, const char *key, binn *value);
+signed char    APIENTRY binn_list_int8(const void *list, int pos);
+short          APIENTRY binn_list_int16(const void *list, int pos);
+int            APIENTRY binn_list_int32(const void *list, int pos);
+int64          APIENTRY binn_list_int64(const void *list, int pos);
+unsigned char  APIENTRY binn_list_uint8(const void *list, int pos);
+unsigned short APIENTRY binn_list_uint16(const void *list, int pos);
+unsigned int   APIENTRY binn_list_uint32(const void *list, int pos);
+uint64         APIENTRY binn_list_uint64(const void *list, int pos);
+float          APIENTRY binn_list_float(const void *list, int pos);
+double         APIENTRY binn_list_double(const void *list, int pos);
+BOOL           APIENTRY binn_list_bool(const void *list, int pos);
+BOOL           APIENTRY binn_list_null(const void *list, int pos);
+char *         APIENTRY binn_list_str(const void *list, int pos);
+void *         APIENTRY binn_list_blob(const void *list, int pos, int *psize);
+void *         APIENTRY binn_list_list(const void *list, int pos);
+void *         APIENTRY binn_list_map(const void *list, int pos);
+void *         APIENTRY binn_list_object(const void *list, int pos);
 
-/*  single interface - these functions check the data type */
-BOOL APIENTRY binn_list_get(void *list, int pos, int type, void *pvalue, int *psize);
-BOOL APIENTRY binn_map_get(void *map, int id, int type, void *pvalue, int *psize);
-BOOL APIENTRY binn_object_get(void *obj, const char *key, int type, void *pvalue, int *psize);
+signed char    APIENTRY binn_map_int8(const void *map, int id);
+short          APIENTRY binn_map_int16(const void *map, int id);
+int            APIENTRY binn_map_int32(const void *map, int id);
+int64          APIENTRY binn_map_int64(const void *map, int id);
+unsigned char  APIENTRY binn_map_uint8(const void *map, int id);
+unsigned short APIENTRY binn_map_uint16(const void *map, int id);
+unsigned int   APIENTRY binn_map_uint32(const void *map, int id);
+uint64         APIENTRY binn_map_uint64(const void *map, int id);
+float          APIENTRY binn_map_float(const void *map, int id);
+double         APIENTRY binn_map_double(const void *map, int id);
+BOOL           APIENTRY binn_map_bool(const void *map, int id);
+BOOL           APIENTRY binn_map_null(const void *map, int id);
+char *         APIENTRY binn_map_str(const void *map, int id);
+void *         APIENTRY binn_map_blob(const void *map, int id, int *psize);
+void *         APIENTRY binn_map_list(const void *map, int id);
+void *         APIENTRY binn_map_map(const void *map, int id);
+void *         APIENTRY binn_map_object(const void *map, int id);
 
-/*  these 3 functions return a pointer to the value and the data type */
-/*  they are thread-safe on big-endian devices */
-/*  on little-endian devices they are thread-safe only to return pointers to list, map, object, blob and strings */
-/*  the returned pointer to 16, 32 and 64 bits values must be used only by single-threaded applications */
-void * APIENTRY binn_list_read(void *list, int pos, int *ptype, int *psize);
-void * APIENTRY binn_map_read(void *map, int id, int *ptype, int *psize);
-void * APIENTRY binn_object_read(void *obj, const char *key, int *ptype, int *psize);
+signed char    APIENTRY binn_object_int8(const void *obj, const char *key);
+short          APIENTRY binn_object_int16(const void *obj, const char *key);
+int            APIENTRY binn_object_int32(const void *obj, const char *key);
+int64          APIENTRY binn_object_int64(const void *obj, const char *key);
+unsigned char  APIENTRY binn_object_uint8(const void *obj, const char *key);
+unsigned short APIENTRY binn_object_uint16(const void *obj, const char *key);
+unsigned int   APIENTRY binn_object_uint32(const void *obj, const char *key);
+uint64         APIENTRY binn_object_uint64(const void *obj, const char *key);
+float          APIENTRY binn_object_float(const void *obj, const char *key);
+double         APIENTRY binn_object_double(const void *obj, const char *key);
+BOOL           APIENTRY binn_object_bool(const void *obj, const char *key);
+BOOL           APIENTRY binn_object_null(const void *obj, const char *key);
+char *         APIENTRY binn_object_str(const void *obj, const char *key);
+void *         APIENTRY binn_object_blob(const void *obj, const char *key, int *psize);
+void *         APIENTRY binn_object_list(const void *obj, const char *key);
+void *         APIENTRY binn_object_map(const void *obj, const char *key);
+void *         APIENTRY binn_object_object(const void *obj, const char *key);
 
 
-/*  READ PAIR FUNCTIONS */
+// return a pointer to an allocated binn structure - must be released with the free() function or equivalent set in binn_set_alloc_functions()
+binn * APIENTRY binn_list_value(const void *list, int pos);
+binn * APIENTRY binn_map_value(const void *map, int id);
+binn * APIENTRY binn_object_value(const void *obj, const char *key);
 
-/*  these functions use base 1 in the 'pos' argument */
+// read the value to a binn structure on the stack
+BOOL APIENTRY binn_list_get_value(const void *list, int pos, binn *value);
+BOOL APIENTRY binn_map_get_value(const void *map, int id, binn *value);
+BOOL APIENTRY binn_object_get_value(const void *obj, const char *key, binn *value);
 
-/*  on stack */
-BOOL APIENTRY binn_map_get_pair(void *map, int pos, int *pid, binn *value);
-BOOL APIENTRY binn_object_get_pair(void *obj, int pos, char *pkey, binn *value);  /*  must free the memory returned in the pkey */
+// single interface - these functions check the data type
+BOOL APIENTRY binn_list_get(const void *list, int pos, int type, void *pvalue, int *psize);
+BOOL APIENTRY binn_map_get(const void *map, int id, int type, void *pvalue, int *psize);
+BOOL APIENTRY binn_object_get(const void *obj, const char *key, int type, void *pvalue, int *psize);
 
-/*  allocated */
-binn * APIENTRY binn_map_pair(void *map, int pos, int *pid);
-binn * APIENTRY binn_object_pair(void *obj, int pos, char *pkey);  /*  must free the memory returned in the pkey */
-
-/*  these 2 functions return a pointer to the value and the data type */
-/*  they are thread-safe on big-endian devices */
-/*  on little-endian devices they are thread-safe only to return pointers to list, map, object, blob and strings */
-/*  the returned pointer to 16, 32 and 64 bits values must be used only by single-threaded applications */
-void * APIENTRY binn_map_read_pair(void *ptr, int pos, int *pid, int *ptype, int *psize);
-void * APIENTRY binn_object_read_pair(void *ptr, int pos, char *pkey, int *ptype, int *psize);
+// these 3 functions return a pointer to the value and the data type
+// they are thread-safe on big-endian devices
+// on little-endian devices they are thread-safe only to return pointers to list, map, object, blob and strings
+// the returned pointer to 16, 32 and 64 bits values must be used only by single-threaded applications
+void * APIENTRY binn_list_read(const void *list, int pos, int *ptype, int *psize);
+void * APIENTRY binn_map_read(const void *map, int id, int *ptype, int *psize);
+void * APIENTRY binn_object_read(const void *obj, const char *key, int *ptype, int *psize);
 
 
-/*  SEQUENTIAL READ FUNCTIONS */
+// READ PAIR FUNCTIONS
+
+// these functions use base 1 in the 'pos' argument
+
+// on stack
+BOOL APIENTRY binn_map_get_pair(const void *map, int pos, int *pid, binn *value);
+BOOL APIENTRY binn_object_get_pair(const void *obj, int pos, char *pkey, binn *value);  // the key must be declared as: char key[256];
+
+// allocated
+binn * APIENTRY binn_map_pair(const void *map, int pos, int *pid);
+binn * APIENTRY binn_object_pair(const void *obj, int pos, char *pkey);  // the key must be declared as: char key[256];
+
+// these 2 functions return a pointer to the value and the data type
+// they are thread-safe on big-endian devices
+// on little-endian devices they are thread-safe only to return pointers to list, map, object, blob and strings
+// the returned pointer to 16, 32 and 64 bits values must be used only by single-threaded applications
+void * APIENTRY binn_map_read_pair(const void *ptr, int pos, int *pid, int *ptype, int *psize);
+void * APIENTRY binn_object_read_pair(const void *ptr, int pos, char *pkey, int *ptype, int *psize);
+
+
+// SEQUENTIAL READ FUNCTIONS
 
 typedef struct binn_iter_struct {
     unsigned char *pnext;
@@ -496,34 +497,34 @@ typedef struct binn_iter_struct {
     int   current;
 } binn_iter;
 
-BOOL   APIENTRY binn_iter_init(binn_iter *iter, void *pbuf, int type);
+BOOL   APIENTRY binn_iter_init(binn_iter *iter, const void *pbuf, int type);
 
-/*  allocated */
+// allocated
 binn * APIENTRY binn_list_next_value(binn_iter *iter);
 binn * APIENTRY binn_map_next_value(binn_iter *iter, int *pid);
-binn * APIENTRY binn_object_next_value(binn_iter *iter, char *pkey);  /*  the key must be declared as: char key[256]; */
+binn * APIENTRY binn_object_next_value(binn_iter *iter, char *pkey);  // the key must be declared as: char key[256];
 
-/*  on stack */
+// on stack
 BOOL   APIENTRY binn_list_next(binn_iter *iter, binn *value);
 BOOL   APIENTRY binn_map_next(binn_iter *iter, int *pid, binn *value);
-BOOL   APIENTRY binn_object_next(binn_iter *iter, char *pkey, binn *value);  /*  the key must be declared as: char key[256]; */
+BOOL   APIENTRY binn_object_next(binn_iter *iter, char *pkey, binn *value);  // the key must be declared as: char key[256];
 
-/*  these 3 functions return a pointer to the value and the data type */
-/*  they are thread-safe on big-endian devices */
-/*  on little-endian devices they are thread-safe only to return pointers to list, map, object, blob and strings */
-/*  the returned pointer to 16, 32 and 64 bits values must be used only by single-threaded applications */
+// these 3 functions return a pointer to the value and the data type
+// they are thread-safe on big-endian devices
+// on little-endian devices they are thread-safe only to return pointers to list, map, object, blob and strings
+// the returned pointer to 16, 32 and 64 bits values must be used only by single-threaded applications
 void * APIENTRY binn_list_read_next(binn_iter *iter, int *ptype, int *psize);
 void * APIENTRY binn_map_read_next(binn_iter *iter, int *pid, int *ptype, int *psize);
-void * APIENTRY binn_object_read_next(binn_iter *iter, char *pkey, int *ptype, int *psize);  /*  the key must be declared as: char key[256]; */
+void * APIENTRY binn_object_read_next(binn_iter *iter, char *pkey, int *ptype, int *psize);  // the key must be declared as: char key[256];
 
 
-/*  --- MACROS ------------------------------------------------------------ */
+// --- MACROS ------------------------------------------------------------
 
 
 #define binn_is_writable(item) (item)->writable;
 
 
-/*  set values on stack allocated binn structures */
+// set values on stack allocated binn structures
 
 #define binn_set_null(item)         do { (item)->type = BINN_NULL; } while (0)
 
@@ -538,25 +539,25 @@ void * APIENTRY binn_object_read_next(binn_iter *iter, char *pkey, int *ptype, i
 #define binn_set_float(item,value)  do { (item)->type = BINN_FLOAT;  (item)->vfloat  = value; (item)->ptr = &((item)->vfloat); } while (0)
 #define binn_set_double(item,value) do { (item)->type = BINN_DOUBLE; (item)->vdouble = value; (item)->ptr = &((item)->vdouble); } while (0)
 
-/* #define binn_set_string(item,str,pfree)    do { (item)->type = BINN_STRING; (item)->ptr = str; (item)->freefn = pfree; } while (0) */
-/* #define binn_set_blob(item,ptr,size,pfree) do { (item)->type = BINN_BLOB;   (item)->ptr = ptr; (item)->freefn = pfree; (item)->size = size; } while (0) */
+//#define binn_set_string(item,str,pfree)    do { (item)->type = BINN_STRING; (item)->ptr = str; (item)->freefn = pfree; } while (0)
+//#define binn_set_blob(item,ptr,size,pfree) do { (item)->type = BINN_BLOB;   (item)->ptr = ptr; (item)->freefn = pfree; (item)->size = size; } while (0)
 BOOL APIENTRY binn_set_string(binn *item, char *str, binn_mem_free pfree);
 BOOL APIENTRY binn_set_blob(binn *item, void *ptr, int size, binn_mem_free pfree);
 
 
-/* #define binn_double(value) {       (item)->type = BINN_DOUBLE; (item)->vdouble = value; (item)->ptr = &((item)->vdouble) } */
+//#define binn_double(value) {       (item)->type = BINN_DOUBLE; (item)->vdouble = value; (item)->ptr = &((item)->vdouble) }
 
 
 
-/*  FOREACH MACROS */
-/*  -------------- */
-/*  */
-/*  We must use these declarations inside the functions that will use the macros: */
-/*  */
-/*   binn_iter iter; */
-/*   binn value; */
-/*   char key[256];  // only for objects */
-/*   int  id;        // only for maps */
+// FOREACH MACROS
+// --------------
+//
+// We must use these declarations inside the functions that will use the macros:
+//
+//  binn_iter iter;
+//  binn value;
+//  char key[256];  // only for objects
+//  int  id;        // only for maps
 
 #define binn_object_foreach(object, key, value)   \
     binn_iter_init(&iter, object, BINN_OBJECT);   \
@@ -570,11 +571,11 @@ BOOL APIENTRY binn_set_blob(binn *item, void *ptr, int size, binn_mem_free pfree
     binn_iter_init(&iter, list, BINN_LIST);       \
     while (binn_list_next(&iter, &value))
 
-/*  If you need nested foreach loops, use the macros below for the nested loop */
-/*  Also we need to add an additional declaration on the function to hold the iterator */
-/*  We can add in the same line as the first iterator: */
-/*  */
-/*   binn_iter iter, iter2; */
+// If you need nested foreach loops, use the macros below for the nested loop
+// Also we need to add an additional declaration on the function to hold the iterator
+// We can add in the same line as the first iterator:
+//
+//  binn_iter iter, iter2;
 
 #define binn_object_foreach2(object, key, value)   \
     binn_iter_init(&iter2, object, BINN_OBJECT);   \
@@ -766,157 +767,157 @@ ALWAYS_INLINE BOOL binn_object_set_value(binn *obj, const char *key, binn *value
 /*** GET FUNCTIONS *******************************************************************/
 /*************************************************************************************/
 
-ALWAYS_INLINE BOOL binn_list_get_int8(void *list, int pos, signed char *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_int8(const void *list, int pos, signed char *pvalue) {
   return binn_list_get(list, pos, BINN_INT8, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_int16(void *list, int pos, short *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_int16(const void *list, int pos, short *pvalue) {
   return binn_list_get(list, pos, BINN_INT16, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_int32(void *list, int pos, int *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_int32(const void *list, int pos, int *pvalue) {
   return binn_list_get(list, pos, BINN_INT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_int64(void *list, int pos, int64 *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_int64(const void *list, int pos, int64 *pvalue) {
   return binn_list_get(list, pos, BINN_INT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_uint8(void *list, int pos, unsigned char *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_uint8(const void *list, int pos, unsigned char *pvalue) {
   return binn_list_get(list, pos, BINN_UINT8, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_uint16(void *list, int pos, unsigned short *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_uint16(const void *list, int pos, unsigned short *pvalue) {
   return binn_list_get(list, pos, BINN_UINT16, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_uint32(void *list, int pos, unsigned int *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_uint32(const void *list, int pos, unsigned int *pvalue) {
   return binn_list_get(list, pos, BINN_UINT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_uint64(void *list, int pos, uint64 *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_uint64(const void *list, int pos, uint64 *pvalue) {
   return binn_list_get(list, pos, BINN_UINT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_float(void *list, int pos, float *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_float(const void *list, int pos, float *pvalue) {
   return binn_list_get(list, pos, BINN_FLOAT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_double(void *list, int pos, double *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_double(const void *list, int pos, double *pvalue) {
   return binn_list_get(list, pos, BINN_FLOAT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_bool(void *list, int pos, BOOL *pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_bool(const void *list, int pos, BOOL *pvalue) {
   return binn_list_get(list, pos, BINN_BOOL, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_str(void *list, int pos, char **pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_str(const void *list, int pos, char **pvalue) {
   return binn_list_get(list, pos, BINN_STRING, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_blob(void *list, int pos, void **pvalue, int *psize) {
+ALWAYS_INLINE BOOL binn_list_get_blob(const void *list, int pos, void **pvalue, int *psize) {
   return binn_list_get(list, pos, BINN_BLOB, pvalue, psize);
 }
-ALWAYS_INLINE BOOL binn_list_get_list(void *list, int pos, void **pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_list(const void *list, int pos, void **pvalue) {
   return binn_list_get(list, pos, BINN_LIST, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_map(void *list, int pos, void **pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_map(const void *list, int pos, void **pvalue) {
   return binn_list_get(list, pos, BINN_MAP, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_list_get_object(void *list, int pos, void **pvalue) {
+ALWAYS_INLINE BOOL binn_list_get_object(const void *list, int pos, void **pvalue) {
   return binn_list_get(list, pos, BINN_OBJECT, pvalue, NULL);
 }
 
 /***************************************************************************/
 
-ALWAYS_INLINE BOOL binn_map_get_int8(void *map, int id, signed char *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_int8(const void *map, int id, signed char *pvalue) {
   return binn_map_get(map, id, BINN_INT8, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_int16(void *map, int id, short *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_int16(const void *map, int id, short *pvalue) {
   return binn_map_get(map, id, BINN_INT16, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_int32(void *map, int id, int *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_int32(const void *map, int id, int *pvalue) {
   return binn_map_get(map, id, BINN_INT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_int64(void *map, int id, int64 *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_int64(const void *map, int id, int64 *pvalue) {
   return binn_map_get(map, id, BINN_INT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_uint8(void *map, int id, unsigned char *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_uint8(const void *map, int id, unsigned char *pvalue) {
   return binn_map_get(map, id, BINN_UINT8, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_uint16(void *map, int id, unsigned short *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_uint16(const void *map, int id, unsigned short *pvalue) {
   return binn_map_get(map, id, BINN_UINT16, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_uint32(void *map, int id, unsigned int *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_uint32(const void *map, int id, unsigned int *pvalue) {
   return binn_map_get(map, id, BINN_UINT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_uint64(void *map, int id, uint64 *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_uint64(const void *map, int id, uint64 *pvalue) {
   return binn_map_get(map, id, BINN_UINT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_float(void *map, int id, float *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_float(const void *map, int id, float *pvalue) {
   return binn_map_get(map, id, BINN_FLOAT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_double(void *map, int id, double *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_double(const void *map, int id, double *pvalue) {
   return binn_map_get(map, id, BINN_FLOAT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_bool(void *map, int id, BOOL *pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_bool(const void *map, int id, BOOL *pvalue) {
   return binn_map_get(map, id, BINN_BOOL, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_str(void *map, int id, char **pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_str(const void *map, int id, char **pvalue) {
   return binn_map_get(map, id, BINN_STRING, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_blob(void *map, int id, void **pvalue, int *psize) {
+ALWAYS_INLINE BOOL binn_map_get_blob(const void *map, int id, void **pvalue, int *psize) {
   return binn_map_get(map, id, BINN_BLOB, pvalue, psize);
 }
-ALWAYS_INLINE BOOL binn_map_get_list(void *map, int id, void **pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_list(const void *map, int id, void **pvalue) {
   return binn_map_get(map, id, BINN_LIST, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_map(void *map, int id, void **pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_map(const void *map, int id, void **pvalue) {
   return binn_map_get(map, id, BINN_MAP, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_map_get_object(void *map, int id, void **pvalue) {
+ALWAYS_INLINE BOOL binn_map_get_object(const void *map, int id, void **pvalue) {
   return binn_map_get(map, id, BINN_OBJECT, pvalue, NULL);
 }
 
 /***************************************************************************/
 
-/*  usage: */
-/*    if (binn_object_get_int32(obj, "key", &value) == FALSE) xxx; */
+// usage:
+//   if (binn_object_get_int32(obj, "key", &value) == FALSE) xxx;
 
-ALWAYS_INLINE BOOL binn_object_get_int8(void *obj, const char *key, signed char *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_int8(const void *obj, const char *key, signed char *pvalue) {
   return binn_object_get(obj, key, BINN_INT8, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_int16(void *obj, const char *key, short *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_int16(const void *obj, const char *key, short *pvalue) {
   return binn_object_get(obj, key, BINN_INT16, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_int32(void *obj, const char *key, int *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_int32(const void *obj, const char *key, int *pvalue) {
   return binn_object_get(obj, key, BINN_INT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_int64(void *obj, const char *key, int64 *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_int64(const void *obj, const char *key, int64 *pvalue) {
   return binn_object_get(obj, key, BINN_INT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_uint8(void *obj, const char *key, unsigned char *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_uint8(const void *obj, const char *key, unsigned char *pvalue) {
   return binn_object_get(obj, key, BINN_UINT8, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_uint16(void *obj, const char *key, unsigned short *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_uint16(const void *obj, const char *key, unsigned short *pvalue) {
   return binn_object_get(obj, key, BINN_UINT16, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_uint32(void *obj, const char *key, unsigned int *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_uint32(const void *obj, const char *key, unsigned int *pvalue) {
   return binn_object_get(obj, key, BINN_UINT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_uint64(void *obj, const char *key, uint64 *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_uint64(const void *obj, const char *key, uint64 *pvalue) {
   return binn_object_get(obj, key, BINN_UINT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_float(void *obj, const char *key, float *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_float(const void *obj, const char *key, float *pvalue) {
   return binn_object_get(obj, key, BINN_FLOAT32, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_double(void *obj, const char *key, double *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_double(const void *obj, const char *key, double *pvalue) {
   return binn_object_get(obj, key, BINN_FLOAT64, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_bool(void *obj, const char *key, BOOL *pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_bool(const void *obj, const char *key, BOOL *pvalue) {
   return binn_object_get(obj, key, BINN_BOOL, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_str(void *obj, const char *key, char **pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_str(const void *obj, const char *key, char **pvalue) {
   return binn_object_get(obj, key, BINN_STRING, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_blob(void *obj, const char *key, void **pvalue, int *psize) {
+ALWAYS_INLINE BOOL binn_object_get_blob(const void *obj, const char *key, void **pvalue, int *psize) {
   return binn_object_get(obj, key, BINN_BLOB, pvalue, psize);
 }
-ALWAYS_INLINE BOOL binn_object_get_list(void *obj, const char *key, void **pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_list(const void *obj, const char *key, void **pvalue) {
   return binn_object_get(obj, key, BINN_LIST, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_map(void *obj, const char *key, void **pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_map(const void *obj, const char *key, void **pvalue) {
   return binn_object_get(obj, key, BINN_MAP, pvalue, NULL);
 }
-ALWAYS_INLINE BOOL binn_object_get_object(void *obj, const char *key, void **pvalue) {
+ALWAYS_INLINE BOOL binn_object_get_object(const void *obj, const char *key, void **pvalue) {
   return binn_object_get(obj, key, BINN_OBJECT, pvalue, NULL);
 }
 
@@ -928,17 +929,17 @@ BOOL   APIENTRY binn_get_double(binn *value, double *pfloat);
 BOOL   APIENTRY binn_get_bool(binn *value, BOOL *pbool);
 char * APIENTRY binn_get_str(binn *value);
 
-/*  boolean string values: */
-/*  1, true, yes, on */
-/*  0, false, no, off */
+// boolean string values:
+// 1, true, yes, on
+// 0, false, no, off
 
-/*  boolean number values: */
-/*  !=0 [true] */
-/*  ==0 [false] */
+// boolean number values:
+// !=0 [true]
+// ==0 [false]
 
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* BINN_H */
+#endif //BINN_H

--- a/channels.c
+++ b/channels.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: channels.c,v 1.435 2023/12/18 14:47:20 djm Exp $ */
+/* $OpenBSD: channels.c,v 1.437 2024/03/06 02:59:59 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -219,6 +219,9 @@ struct ssh_channels {
 	/* Channel timeouts by type */
 	struct ssh_channel_timeout *timeouts;
 	size_t ntimeouts;
+	/* Global timeout for all OPEN channels */
+	int global_deadline;
+	time_t lastused;
 };
 
 /* helper */
@@ -324,6 +327,11 @@ channel_add_timeout(struct ssh *ssh, const char *type_pattern,
 {
 	struct ssh_channels *sc = ssh->chanctxt;
 
+	if (strcmp(type_pattern, "global") == 0) {
+		debug2_f("global channel timeout %d seconds", timeout_secs);
+		sc->global_deadline = timeout_secs;
+		return;
+	}
 	debug2_f("channel type \"%s\" timeout %d seconds",
 	    type_pattern, timeout_secs);
 	sc->timeouts = xrecallocarray(sc->timeouts, sc->ntimeouts,
@@ -382,6 +390,38 @@ channel_set_xtype(struct ssh *ssh, int id, const char *xctype)
 	c->inactive_deadline = lookup_timeout(ssh, c->xctype);
 	debug2_f("labeled channel %d as %s (inactive timeout %u)", id, xctype,
 	    c->inactive_deadline);
+}
+
+/*
+ * update "last used" time on a channel.
+ * NB. nothing else should update lastused except to clear it.
+ */
+static void
+channel_set_used_time(struct ssh *ssh, Channel *c)
+{
+	ssh->chanctxt->lastused = monotime();
+	if (c != NULL)
+		c->lastused = ssh->chanctxt->lastused;
+}
+
+/*
+ * Get the time at which a channel is due to time out for inactivity.
+ * Returns 0 if the channel is not due to time out ever.
+ */
+static time_t
+channel_get_expiry(struct ssh *ssh, Channel *c)
+{
+	struct ssh_channels *sc = ssh->chanctxt;
+	time_t expiry = 0, channel_expiry;
+
+	if (sc->lastused != 0 && sc->global_deadline != 0)
+		expiry = sc->lastused + sc->global_deadline;
+	if (c->lastused != 0 && c->inactive_deadline != 0) {
+		channel_expiry = c->lastused + c->inactive_deadline;
+		if (expiry == 0 || channel_expiry < expiry)
+			expiry = channel_expiry;
+	}
+	return expiry;
 }
 
 /*
@@ -449,6 +489,8 @@ channel_register_fds(struct ssh *ssh, Channel *c, int rfd, int wfd, int efd,
 		if (efd != -1)
 			set_nonblock(efd);
 	}
+	/* channel might be entering a larval state, so reset global timeout */
+	channel_set_used_time(ssh, NULL);
 }
 
 /*
@@ -1209,7 +1251,7 @@ channel_set_fds(struct ssh *ssh, int id, int rfd, int wfd, int efd,
 
 	channel_register_fds(ssh, c, rfd, wfd, efd, extusage, nonblock, is_tty);
 	c->type = SSH_CHANNEL_OPEN;
-	c->lastused = monotime();
+	channel_set_used_time(ssh, c);
 	c->local_window = c->local_window_max = window_max;
 
 	if ((r = sshpkt_start(ssh, SSH2_MSG_CHANNEL_WINDOW_ADJUST)) != 0 ||
@@ -1407,7 +1449,7 @@ channel_pre_x11_open(struct ssh *ssh, Channel *c)
 
 	if (ret == 1) {
 		c->type = SSH_CHANNEL_OPEN;
-		c->lastused = monotime();
+		channel_set_used_time(ssh, c);
 		channel_pre_open(ssh, c);
 	} else if (ret == -1) {
 		logit("X11 connection rejected because of wrong "
@@ -2055,7 +2097,7 @@ channel_post_connecting(struct ssh *ssh, Channel *c)
 		    c->self, c->connect_ctx.host, c->connect_ctx.port);
 		channel_connect_ctx_free(&c->connect_ctx);
 		c->type = SSH_CHANNEL_OPEN;
-		c->lastused = monotime();
+		channel_set_used_time(ssh, c);
 		if (isopen) {
 			/* no message necessary */
 		} else {
@@ -2147,7 +2189,7 @@ channel_handle_rfd(struct ssh *ssh, Channel *c)
 			goto rfail;
 		}
 		if (nr != 0)
-			c->lastused = monotime();
+			channel_set_used_time(ssh, c);
 		return 1;
 	}
 
@@ -2173,7 +2215,7 @@ channel_handle_rfd(struct ssh *ssh, Channel *c)
 		}
 		return -1;
 	}
-	c->lastused = monotime();
+	channel_set_used_time(ssh, c);
 	if (c->input_filter != NULL) {
 		if (c->input_filter(ssh, c, buf, len) == -1) {
 			debug2("channel %d: filter stops", c->self);
@@ -2254,7 +2296,7 @@ channel_handle_wfd(struct ssh *ssh, Channel *c)
 		}
 		return -1;
 	}
-	c->lastused = monotime();
+	channel_set_used_time(ssh, c);
 #ifndef BROKEN_TCGETATTR_ICANON
 	if (c->isatty && dlen >= 1 && buf[0] != '\r') {
 		if (tcgetattr(c->wfd, &tio) == 0 &&
@@ -2302,7 +2344,7 @@ channel_handle_efd_write(struct ssh *ssh, Channel *c)
 		if ((r = sshbuf_consume(c->extended, len)) != 0)
 			fatal_fr(r, "channel %i: consume", c->self);
 		c->local_consumed += len;
-		c->lastused = monotime();
+		channel_set_used_time(ssh, c);
 	}
 	return 1;
 }
@@ -2329,7 +2371,7 @@ channel_handle_efd_read(struct ssh *ssh, Channel *c)
 		channel_close_fd(ssh, c, &c->efd);
 		return 1;
 	}
-	c->lastused = monotime();
+	channel_set_used_time(ssh, c);
 	if (c->extended_usage == CHAN_EXTENDED_IGNORE)
 		debug3("channel %d: discard efd", c->self);
 	else if ((r = sshbuf_put(c->extended, buf, len)) != 0)
@@ -2649,10 +2691,9 @@ channel_handler(struct ssh *ssh, int table, struct timespec *timeout)
 				continue;
 		}
 		if (ftab[c->type] != NULL) {
-			if (table == CHAN_PRE &&
-			    c->type == SSH_CHANNEL_OPEN &&
-			    c->inactive_deadline != 0 && c->lastused != 0 &&
-			    now >= c->lastused + c->inactive_deadline) {
+			if (table == CHAN_PRE && c->type == SSH_CHANNEL_OPEN &&
+			    channel_get_expiry(ssh, c) != 0 &&
+			    now >= channel_get_expiry(ssh, c)) {
 				/* channel closed for inactivity */
 				verbose("channel %d: closing after %u seconds "
 				    "of inactivity", c->self,
@@ -2664,10 +2705,9 @@ channel_handler(struct ssh *ssh, int table, struct timespec *timeout)
 				/* inactivity timeouts must interrupt poll() */
 				if (timeout != NULL &&
 				    c->type == SSH_CHANNEL_OPEN &&
-				    c->lastused != 0 &&
-				    c->inactive_deadline != 0) {
+				    channel_get_expiry(ssh, c) != 0) {
 					ptimeout_deadline_monotime(timeout,
-					    c->lastused + c->inactive_deadline);
+					    channel_get_expiry(ssh, c));
 				}
 			} else if (timeout != NULL) {
 				/*
@@ -3271,9 +3311,8 @@ channel_proxy_downstream(struct ssh *ssh, Channel *downstream)
 			goto out;
 		}
 		/* Record that connection to this host/port is permitted. */
-		permission_set_add(ssh, FORWARD_USER, FORWARD_LOCAL, "<mux>", -1,
-		    listen_host, NULL, (int)listen_port, downstream);
-		listen_host = NULL;
+		permission_set_add(ssh, FORWARD_USER, FORWARD_LOCAL, "<mux>",
+		    -1, listen_host, NULL, (int)listen_port, downstream);
 		break;
 	case SSH2_MSG_CHANNEL_CLOSE:
 		if (have < 4)
@@ -3624,7 +3663,7 @@ channel_input_open_confirmation(int type, u_int32_t seq, struct ssh *ssh)
 		c->open_confirm(ssh, c->self, 1, c->open_confirm_ctx);
 		debug2_f("channel %d: callback done", c->self);
 	}
-	c->lastused = monotime();
+	channel_set_used_time(ssh, c);
 	debug2("channel %d: open confirm rwindow %u rmax %u", c->self,
 	    c->remote_window, c->remote_maxpacket);
 	return 0;

--- a/cipher-ctr-mt-functions.c
+++ b/cipher-ctr-mt-functions.c
@@ -608,9 +608,15 @@ int aes_mt_do_cipher(void *vevp_ctx,
 		 * may need to do it in 8 or 4 bytes chunks
 		 * worst case is doing it as a loop */
 #ifdef CIPHER_INT128_OK
-		if ((align & 0xf) == 0) {
-			destp.u128[0] = srcp.u128[0] ^ bufp.u128[0];
-		} else
+		/* with GCC 13 we have having consistent seg faults
+		 * in this section of code. Since this is a critical
+		 * code path we are removing this until we have a solution
+		 * in place -cjr 02/22/24
+		 * TODO: FIX THIS
+		 */
+		/* if ((align & 0xf) == 0) { */
+		/* 	destp.u128[0] = srcp.u128[0] ^ bufp.u128[0]; */
+		/* } else */
 #endif
 		/* 64 bits */
 		if ((align & 0x7) == 0) {

--- a/cipher-ctr-mt.c
+++ b/cipher-ctr-mt.c
@@ -461,9 +461,15 @@ ssh_aes_ctr(EVP_CIPHER_CTX *ctx, u_char *dest, const u_char *src,
 		 * may need to do it in 8 or 4 bytes chunks
 		 * worst case is doing it as a loop */
 #ifdef CIPHER_INT128_OK
-		if ((align & 0xf) == 0) {
-			destp.u128[0] = srcp.u128[0] ^ bufp.u128[0];
-		} else
+		/* with GCC 13 we have having consistent seg faults
+		 * in this section of code. Since this is a critical
+		 * code path we are removing this until we have a solution
+		 * in place -cjr 02/22/24
+		 * TODO: FIX THIS
+		 */
+		/* if ((align & 0xf) == 0) { */
+		/* 	destp.u128[0] = srcp.u128[0] ^ bufp.u128[0]; */
+		/* } else */
 #endif
 		/* 64 bits */
 		if ((align & 0x7) == 0) {

--- a/clientloop.c
+++ b/clientloop.c
@@ -2766,7 +2766,7 @@ client_process_request_metrics (struct ssh *ssh, int type, u_int32_t seq, void *
 	kernel_version = binn_object_int32((void *)blob, "kernel_version");
 
 	/* create a string of the data from the binn object blob */
-	metrics_read_binn_object((void *)blob, &metricsstring);
+	metrics_read_binn_object((void *)blob, metricsstring);
 
 	/* have we printed the header? */
 	if (metrics_hdr_remote_flag == 0) {
@@ -2811,7 +2811,7 @@ localonly:
 	metrics_write_binn_object(&local_tcp_info, metricsobj);
 
 	/* create a string of the data from the binn object metricsobj */
-	metrics_read_binn_object((void *)metricsobj, &metricsstring);
+	metrics_read_binn_object((void *)metricsobj, metricsstring);
 
 	/* get the kernel version printing the header */
 	kernel_version = binn_object_int32(metricsobj, "kernel_version");

--- a/clientloop.c
+++ b/clientloop.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: clientloop.c,v 1.402 2023/11/24 00:31:30 dtucker Exp $ */
+/* $OpenBSD: clientloop.c,v 1.403 2024/02/21 05:57:34 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -525,7 +525,7 @@ send_chaff(struct ssh *ssh)
 {
 	int r;
 
-	if ((ssh->kex->flags & KEX_HAS_PING) == 0)
+	if (ssh->kex == NULL || (ssh->kex->flags & KEX_HAS_PING) == 0)
 		return 0;
 	/* XXX probabilistically send chaff? */
 	/*

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-AC_INIT([OpenSSH], [Portable], [openssh-unix-dev@mindrot.org])
+AC_INIT([OpenSSH],[Portable],[openssh-unix-dev@mindrot.org])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([ssh.c])
 

--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,7 @@ fi
 
 use_stack_protector=1
 use_toolchain_hardening=1
+use_retpoline=1
 AC_ARG_WITH([stackprotect],
     [  --without-stackprotect  Don't use compiler's stack protection], [
     if test "x$withval" = "xno"; then
@@ -158,6 +159,11 @@ AC_ARG_WITH([hardening],
     [  --without-hardening     Don't use toolchain hardening flags], [
     if test "x$withval" = "xno"; then
 	use_toolchain_hardening=0
+    fi ])
+AC_ARG_WITH([retpoline],
+    [  --without-retpoline     Enable retpoline spectre mitigation], [
+    if test "x$withval" = "xno"; then
+	use_retpoline=0
     fi ])
 
 # We use -Werror for the tests only so that we catch warnings like "this is
@@ -216,8 +222,6 @@ if test "$GCC" = "yes" || test "$GCC" = "egcs"; then
 	OSSH_CHECK_CFLAG_COMPILE([-Wbitwise-instead-of-logical])
 	OSSH_CHECK_CFLAG_COMPILE([-fno-strict-aliasing])
     if test "x$use_toolchain_hardening" = "x1"; then
-	OSSH_CHECK_CFLAG_COMPILE([-mretpoline]) # clang
-	OSSH_CHECK_LDFLAG_LINK([-Wl,-z,retpolineplt])
 	OSSH_CHECK_CFLAG_COMPILE([-D_FORTIFY_SOURCE=2])
 	OSSH_CHECK_LDFLAG_LINK([-Wl,-z,relro])
 	OSSH_CHECK_LDFLAG_LINK([-Wl,-z,now])
@@ -239,6 +243,10 @@ if test "$GCC" = "yes" || test "$GCC" = "egcs"; then
 	*)	OSSH_CHECK_CFLAG_LINK([-fzero-call-used-regs=used]) ;;
 	esac
 	OSSH_CHECK_CFLAG_COMPILE([-ftrivial-auto-var-init=zero])
+    fi
+    if test "x$use_retpoline" = "x1"; then
+	OSSH_CHECK_CFLAG_COMPILE([-mretpoline]) # clang
+	OSSH_CHECK_LDFLAG_LINK([-Wl,-z,retpolineplt])
     fi
 
 	AC_MSG_CHECKING([if $CC accepts -fno-builtin-memset])
@@ -2067,6 +2075,18 @@ AC_ARG_WITH([security-key-builtin],
 	[ enable_sk_internal=$withval ]
 )
 
+disable_ecdsa=
+AC_ARG_ENABLE([dsa-keys],
+	[  --disable-dsa-keys      disable DSA key support [no]],
+	[
+		if test "x$enableval" = "xno" ; then
+			disable_ecdsa=1
+		fi
+	]
+)
+test -z "$disable_ecdsa" &&
+    AC_DEFINE([WITH_DSA], [1], [Define if to enable DSA keys.])
+
 AC_SEARCH_LIBS([dlopen], [dl])
 AC_CHECK_FUNCS([dlopen])
 AC_CHECK_DECL([RTLD_NOW], [], [], [#include <dlfcn.h>])
@@ -2723,7 +2743,15 @@ AC_ARG_WITH([ssl-dir],
 			else
 				CPPFLAGS="-I${withval} ${CPPFLAGS}"
 			fi
-			openssl_bin_PATH="${PATH}${PATH_SEPARATOR}${withval}/bin${PATH_SEPARATOR}${withval}/apps"
+			dnl Ensure specified openssl binary works, eg it can
+			dnl find its runtime libraries, before trying to use.
+			if test -x "${withval}/bin/openssl" && \
+			    "${withval}/bin/openssl" version >/dev/null 2>&1; then
+				openssl_bin_PATH="${withval}/bin${PATH_SEPARATOR}${PATH}"
+			elif test -x "${withval}/apps/openssl" && \
+			    "${withval}/apps/openssl" version >/dev/null 2>&1; then
+				openssl_bin_PATH="${withval}/apps${PATH_SEPARATOR}${PATH}"
+			fi
 		fi
 	]
 )
@@ -2790,8 +2818,8 @@ if test "x$openssl" = "xyes" ; then
 			AC_MSG_RESULT([$ssl_header_ver])
 		],
 		[
-			AC_MSG_RESULT([not found])
-			AC_MSG_ERROR([OpenSSL version header not found.])
+			AC_MSG_RESULT([failed])
+			AC_MSG_ERROR([OpenSSL version test program failed.])
 		],
 		[
 			AC_MSG_WARN([cross compiling: not checking])
@@ -3022,7 +3050,7 @@ if test "x$openssl" = "xyes" ; then
 
 
 	# Check for OpenSSL without EVP_aes_{192,256}_cbc
-	AC_MSG_CHECKING([whether OpenSSL has crippled AES support])
+	AC_MSG_CHECKING([whether OpenSSL lacks support for AES 192/256])
 	AC_LINK_IFELSE(
 		[AC_LANG_PROGRAM([[
 	#include <stdlib.h>
@@ -5320,6 +5348,16 @@ AC_ARG_WITH([pid-dir],
 AC_DEFINE_UNQUOTED([_PATH_SSH_PIDDIR], ["$piddir"],
 	[Specify location of ssh.pid])
 AC_SUBST([piddir])
+
+
+AC_ARG_ENABLE([fd-passing],
+	[  --disable-fd-passing    disable file descriptor passsing [no]],
+	[
+		if test "x$enableval" = "xno" ; then
+			AC_DEFINE([DISABLE_FD_PASSING])
+		fi
+	]
+)
 
 dnl allow user to disable some login recording features
 AC_ARG_ENABLE([lastlog],

--- a/contrib/redhat/openssh.spec
+++ b/contrib/redhat/openssh.spec
@@ -1,4 +1,4 @@
-%global ver 9.6p1
+%global ver 9.7p1
 %global rel 1%{?dist}
 
 # OpenSSH privilege separation requires a user & group ID

--- a/contrib/suse/openssh.spec
+++ b/contrib/suse/openssh.spec
@@ -13,7 +13,7 @@
 
 Summary:	OpenSSH, a free Secure Shell (SSH) protocol implementation
 Name:		openssh
-Version:	9.6p1
+Version:	9.7p1
 URL:		https://www.openssh.com/
 Release:	1
 Source0:	openssh-%{version}.tar.gz

--- a/gss-genr.c
+++ b/gss-genr.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: gss-genr.c,v 1.28 2021/01/27 10:05:28 djm Exp $ */
+/* $OpenBSD: gss-genr.c,v 1.29 2024/02/01 02:37:33 djm Exp $ */
 
 /*
  * Copyright (c) 2001-2007 Simon Wilkinson. All rights reserved.
@@ -278,7 +278,7 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx, gss_OID oid, const char *host)
 	gss_OID_desc spnego_oid = {6, (void *)"\x2B\x06\x01\x05\x05\x02"};
 
 	/* RFC 4462 says we MUST NOT do SPNEGO */
-	if (oid->length == spnego_oid.length && 
+	if (oid->length == spnego_oid.length &&
 	    (memcmp(oid->elements, spnego_oid.elements, oid->length) == 0))
 		return 0; /* false */
 
@@ -286,7 +286,7 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx, gss_OID oid, const char *host)
 	ssh_gssapi_set_oid(*ctx, oid);
 	major = ssh_gssapi_import_name(*ctx, host);
 	if (!GSS_ERROR(major)) {
-		major = ssh_gssapi_init_ctx(*ctx, 0, GSS_C_NO_BUFFER, &token, 
+		major = ssh_gssapi_init_ctx(*ctx, 0, GSS_C_NO_BUFFER, &token,
 		    NULL);
 		gss_release_buffer(&minor, &token);
 		if ((*ctx)->context != GSS_C_NO_CONTEXT)
@@ -294,7 +294,7 @@ ssh_gssapi_check_mechanism(Gssctxt **ctx, gss_OID oid, const char *host)
 			    GSS_C_NO_BUFFER);
 	}
 
-	if (GSS_ERROR(major)) 
+	if (GSS_ERROR(major))
 		ssh_gssapi_delete_ctx(ctx);
 
 	return (!GSS_ERROR(major));

--- a/hpnssh-add.1
+++ b/hpnssh-add.1
@@ -35,25 +35,15 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-<<<<<<< HEAD:hpnssh-add.1
-.Dd $Mdocdate: December 18 2023 $
-.Dt HPNSSH-ADD 1
-=======
 .Dd $Mdocdate: December 19 2023 $
-.Dt SSH-ADD 1
->>>>>>> V_9_7_P1:ssh-add.1
+.Dt HPNSSH-ADD 1
 .Os
 .Sh NAME
 .Nm hpnssh-add
 .Nd adds private key identities to the OpenSSH authentication agent
 .Sh SYNOPSIS
-<<<<<<< HEAD:hpnssh-add.1
 .Nm hpnssh-add
-.Op Fl cCDdKkLlqvXx
-=======
-.Nm ssh-add
 .Op Fl CcDdKkLlqvXx
->>>>>>> V_9_7_P1:ssh-add.1
 .Op Fl E Ar fingerprint_hash
 .Op Fl H Ar hostkey_file
 .Op Fl h Ar destination_constraint

--- a/hpnssh-add.1
+++ b/hpnssh-add.1
@@ -1,4 +1,4 @@
-.\"	$OpenBSD: ssh-add.1,v 1.85 2023/12/18 14:46:56 djm Exp $
+.\"	$OpenBSD: ssh-add.1,v 1.86 2023/12/19 06:57:34 jmc Exp $
 .\"
 .\" Author: Tatu Ylonen <ylo@cs.hut.fi>
 .\" Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -35,15 +35,25 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
+<<<<<<< HEAD:hpnssh-add.1
 .Dd $Mdocdate: December 18 2023 $
 .Dt HPNSSH-ADD 1
+=======
+.Dd $Mdocdate: December 19 2023 $
+.Dt SSH-ADD 1
+>>>>>>> V_9_7_P1:ssh-add.1
 .Os
 .Sh NAME
 .Nm hpnssh-add
 .Nd adds private key identities to the OpenSSH authentication agent
 .Sh SYNOPSIS
+<<<<<<< HEAD:hpnssh-add.1
 .Nm hpnssh-add
 .Op Fl cCDdKkLlqvXx
+=======
+.Nm ssh-add
+.Op Fl CcDdKkLlqvXx
+>>>>>>> V_9_7_P1:ssh-add.1
 .Op Fl E Ar fingerprint_hash
 .Op Fl H Ar hostkey_file
 .Op Fl h Ar destination_constraint
@@ -52,7 +62,7 @@
 .Op Ar
 .Nm hpnssh-add
 .Fl s Ar pkcs11
-.Op Fl vC
+.Op Fl Cv
 .Op Ar certificate ...
 .Nm hpnssh-add
 .Fl e Ar pkcs11
@@ -98,6 +108,9 @@ to work.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
+.It Fl C
+When loading keys into or deleting keys from the agent, process
+certificates only and skip plain keys.
 .It Fl c
 Indicates that added identities should be subject to confirmation before
 being used for authentication.
@@ -106,9 +119,6 @@ Confirmation is performed by
 Successful confirmation is signaled by a zero exit status from
 .Xr ssh-askpass 1 ,
 rather than text entered into the requester.
-.It Fl C
-When loading keys into or deleting keys from the agent, process
-certificates only and skip plain keys.
 .It Fl D
 Deletes all identities from the agent.
 .It Fl d

--- a/hpnssh.1
+++ b/hpnssh.1
@@ -79,7 +79,12 @@ X11 connections, arbitrary TCP ports and
 sockets can also be forwarded over the secure channel.
 .Nm
 is binary compatible with the more well known OpenSSH and uses the same configuration
-directives, methods, and keywords except where noted. 
+directives, methods, and keywords except where noted with the exception of the default port.
+HPN-SSH servers, by default, use port 2222 for connection, and as such,
+.Nm
+clients
+attempt to connect on that port. If the connection attempt on port 2222 fails it will fallback to
+port 22. Please see the -p switch for more information.
 .Pp
 .Nm
 connects and logs into the specified
@@ -531,6 +536,7 @@ For full details of the options listed below, and their possible values, see
 .It EnableEscapeCommandline
 .It EscapeChar
 .It ExitOnForwardFailure
+.It FallbackPort
 .It FingerprintHash
 .It ForkAfterAuthentication
 .It ForwardAgent
@@ -607,7 +613,7 @@ For full details of the options listed below, and their possible values, see
 .It VisualHostKey
 .It XAuthLocation
 .Pp
-.It * Hpnssh specific configuration option.  
+.It * Hpnssh specific configuration option.
 .El
 .Pp
 .It Fl P Ar tag
@@ -624,6 +630,13 @@ for more information.
 Port to connect to on the remote host.
 This can be specified on a
 per-host basis in the configuration file.
+HPN-SSH uses a default port of 2222. It will automatically
+fallback to use the SSH standard port 22 if it cannot connect
+on port 2222. This fallback behaviour can be modified with the
+FallbackPort option. Note: if outbound port 2222 is
+blocked it may appear that the hpnssh client is non-responsive. In that event,
+either specify the correct port or use the ConnectTimeout option
+to trigger the port fallback more quickly.
 .Pp
 .It Fl Q Ar query_option
 Queries for the algorithms supported by one of the following features:
@@ -1813,4 +1826,4 @@ protocol versions 1.5 and 2.0.
 Chris Rapier, Michael Stevens, Ben Bennet, and Mike Tasota developed
 the HPN extensions at the Pittsburgh Supercomuting Center with grants
 from Cisco, the National Library of Medicine, and the National Science
-Foundation. 
+Foundation.

--- a/hpnssh_config.5
+++ b/hpnssh_config.5
@@ -33,15 +33,9 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-<<<<<<< HEAD:hpnssh_config.5
-.\" $OpenBSD: ssh_config.5,v 1.391 2023/10/12 02:18:18 djm Exp $
-.Dd $Mdocdate: October 12 2023 $
-.Dt HPNSSH_CONFIG 5
-=======
 .\" $OpenBSD: ssh_config.5,v 1.394 2024/02/21 06:01:13 djm Exp $
 .Dd $Mdocdate: February 21 2024 $
-.Dt SSH_CONFIG 5
->>>>>>> V_9_7_P1:ssh_config.5
+.Dt HPNSSH_CONFIG 5
 .Os
 .Sh NAME
 .Nm hpnssh_config

--- a/hpnssh_config.5
+++ b/hpnssh_config.5
@@ -33,9 +33,15 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
+<<<<<<< HEAD:hpnssh_config.5
 .\" $OpenBSD: ssh_config.5,v 1.391 2023/10/12 02:18:18 djm Exp $
 .Dd $Mdocdate: October 12 2023 $
 .Dt HPNSSH_CONFIG 5
+=======
+.\" $OpenBSD: ssh_config.5,v 1.394 2024/02/21 06:01:13 djm Exp $
+.Dd $Mdocdate: February 21 2024 $
+.Dt SSH_CONFIG 5
+>>>>>>> V_9_7_P1:ssh_config.5
 .Os
 .Sh NAME
 .Nm hpnssh_config
@@ -157,7 +163,7 @@ The available criteria keywords are:
 .Cm localnetwork ,
 .Cm host ,
 .Cm originalhost ,
-.Cm Tag ,
+.Cm tagged ,
 .Cm user ,
 and
 .Cm localuser .
@@ -476,8 +482,10 @@ Timeouts are specified as one or more
 .Dq type=interval
 pairs separated by whitespace, where the
 .Dq type
-must be a channel type name (as described in the table below), optionally
-containing wildcard characters.
+must be the special keyword
+.Dq global
+or a channel type name from the list below, optionally containing
+wildcard characters.
 .Pp
 The timeout value
 .Dq interval
@@ -486,11 +494,19 @@ is specified in seconds or may use any of the units documented in the
 section.
 For example,
 .Dq session=5m
-would cause the interactive session to terminate after five minutes of
+would cause interactive sessions to terminate after five minutes of
 inactivity.
 Specifying a zero value disables the inactivity timeout.
 .Pp
-The available channel types include:
+The special timeout
+.Dq global
+applies to all active channels, taken together.
+Traffic on any active channel will reset the timeout, but when the timeout
+expires then all open channels will be closed.
+Note that this global timeout is not matched by wildcards and must be
+specified explicitly.
+.Pp
+The available channel type names include:
 .Bl -tag -width Ds
 .It Cm agent-connection
 Open connections to

--- a/hpnssh_config.5
+++ b/hpnssh_config.5
@@ -723,11 +723,6 @@ If set to a time in seconds, or a time in any of the formats documented in
 then the backgrounded master connection will automatically terminate
 after it has remained idle (with no client connections) for the
 specified time.
-.It Cm DisableMTAES
-Switch the encryption cipher being used from the multithreaded MT-AES-CTR cipher
-back to the stock single-threaded AES-CTR cipher. This may prove to be more
-effcient in some circumstances. Default is 
-.Cm no. HPNSSH only.
 .It Cm DynamicForward
 Specifies that a TCP port on the local machine be forwarded
 over the secure channel, and the application
@@ -813,6 +808,9 @@ The argument must be
 or
 .Cm no
 (the default).
+.It Cm FallbackPort
+Specifies the port hpnssh should try to connect to if it fails connecting to the 
+default hpnsshd port of 2222. The default is port 22. HPN-SSH only. 
 .It Cm FingerprintHash
 Specifies the hash algorithm used when displaying key fingerprints.
 Valid options are:

--- a/hpnsshd_config.5
+++ b/hpnsshd_config.5
@@ -33,9 +33,15 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
+<<<<<<< HEAD:hpnsshd_config.5
 .\" $OpenBSD: sshd_config.5,v 1.350 2023/07/28 05:42:36 jmc Exp $
 .Dd $Mdocdate: July 28 2023 $
 .Dt HPNSSHD_CONFIG 5
+=======
+.\" $OpenBSD: sshd_config.5,v 1.355 2024/02/21 06:17:29 djm Exp $
+.Dd $Mdocdate: February 21 2024 $
+.Dt SSHD_CONFIG 5
+>>>>>>> V_9_7_P1:sshd_config.5
 .Os
 .Sh NAME
 .Nm hpnsshd_config
@@ -419,8 +425,10 @@ Timeouts are specified as one or more
 .Dq type=interval
 pairs separated by whitespace, where the
 .Dq type
-must be a channel type name (as described in the table below), optionally
-containing wildcard characters.
+must be the special keyword
+.Dq global
+or a channel type name from the list below, optionally containing
+wildcard characters.
 .Pp
 The timeout value
 .Dq interval
@@ -428,11 +436,20 @@ is specified in seconds or may use any of the units documented in the
 .Sx TIME FORMATS
 section.
 For example,
-.Dq session:*=5m
-would cause all sessions to terminate after five minutes of inactivity.
+.Dq session=5m
+would cause interactive sessions to terminate after five minutes of
+inactivity.
 Specifying a zero value disables the inactivity timeout.
 .Pp
-The available channel types include:
+The special timeout
+.Dq global
+applies to all active channels, taken together.
+Traffic on any active channel will reset the timeout, but when the timeout
+expires then all open channels will be closed.
+Note that this global timeout is not matched by wildcards and must be
+specified explicitly.
+.Pp
+The available channel type names include:
 .Bl -tag -width Ds
 .It Cm agent-connection
 Open connections to
@@ -453,15 +470,15 @@ listening on behalf of a
 .Xr ssh 1
 remote forwarding, i.e.\&
 .Cm RemoteForward .
-.It Cm session:command
-Command execution sessions.
-.It Cm session:shell
-Interactive shell sessions.
-.It Cm session:subsystem:...
-Subsystem sessions, e.g. for
+.It Cm session
+The interactive main session, including shell session, command execution,
+.Xr scp 1 ,
 .Xr sftp 1 ,
-which could be identified as
-.Cm session:subsystem:sftp .
+etc.
+.It Cm tun-connection
+Open
+.Cm TunnelForward
+connections.
 .It Cm x11-connection
 Open X11 forwarding sessions.
 .El
@@ -475,9 +492,6 @@ close the SSH connection, nor does it prevent a client from
 requesting another channel of the same type.
 In particular, expiring an inactive forwarding session does not prevent
 another identical forwarding from being subsequently created.
-See also
-.Cm UnusedConnectionTimeout ,
-which may be used in conjunction with this option.
 .Pp
 The default is not to expire channels of any type for inactivity.
 .It Cm ChrootDirectory
@@ -487,7 +501,7 @@ to after authentication.
 At session startup
 .Xr sshd 8
 checks that all components of the pathname are root-owned directories
-which are not writable by any other user or group.
+which are not writable by group or others.
 After the chroot,
 .Xr sshd 8
 changes the working directory to the user's home directory.
@@ -1147,7 +1161,8 @@ DEBUG and DEBUG1 are equivalent.
 DEBUG2 and DEBUG3 each specify higher levels of debugging output.
 Logging with a DEBUG level violates the privacy of users and is not recommended.
 .It Cm LogVerbose
-Specify one or more overrides to LogLevel.
+Specify one or more overrides to
+.Cm LogLevel .
 An override consists of a pattern lists that matches the source file, function
 and line number to force detailed logging for.
 For example, an override pattern of:
@@ -1825,6 +1840,14 @@ implements an in-process SFTP server.
 This may simplify configurations using
 .Cm ChrootDirectory
 to force a different filesystem root on clients.
+It accepts the same command line arguments as
+.Cm sftp-server
+and even though it is in-process, settings such as
+.Cm LogLevel
+or
+.Cm SyslogFacility
+do not apply to it and must be set explicitly via
+command line arguments.
 .Pp
 By default no subsystems are defined.
 .It Cm SyslogFacility

--- a/hpnsshd_config.5
+++ b/hpnsshd_config.5
@@ -33,15 +33,9 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-<<<<<<< HEAD:hpnsshd_config.5
-.\" $OpenBSD: sshd_config.5,v 1.350 2023/07/28 05:42:36 jmc Exp $
-.Dd $Mdocdate: July 28 2023 $
-.Dt HPNSSHD_CONFIG 5
-=======
 .\" $OpenBSD: sshd_config.5,v 1.355 2024/02/21 06:17:29 djm Exp $
 .Dd $Mdocdate: February 21 2024 $
-.Dt SSHD_CONFIG 5
->>>>>>> V_9_7_P1:sshd_config.5
+.Dt HPNSSHD_CONFIG 5
 .Os
 .Sh NAME
 .Nm hpnsshd_config

--- a/kex.c
+++ b/kex.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: kex.c,v 1.184 2023/12/18 14:45:49 djm Exp $ */
+/* $OpenBSD: kex.c,v 1.185 2024/01/08 00:34:33 djm Exp $ */
 /*
  * Copyright (c) 2000, 2001 Markus Friedl.  All rights reserved.
  *
@@ -773,10 +773,11 @@ static int
 kex_input_newkeys(int type, u_int32_t seq, struct ssh *ssh)
 {
 	struct kex *kex = ssh->kex;
-	int r;
+	int r, initial = (kex->flags & KEX_INITIAL) != 0;
+	char *cp, **prop;
 
 	debug("SSH2_MSG_NEWKEYS received");
-	if (kex->ext_info_c && (kex->flags & KEX_INITIAL) != 0)
+	if (kex->ext_info_c && initial)
 		ssh_dispatch_set(ssh, SSH2_MSG_EXT_INFO, &kex_input_ext_info);
 	ssh_dispatch_set(ssh, SSH2_MSG_NEWKEYS, &kex_protocol_error);
 	ssh_dispatch_set(ssh, SSH2_MSG_KEXINIT, &kex_input_kexinit);
@@ -784,10 +785,32 @@ kex_input_newkeys(int type, u_int32_t seq, struct ssh *ssh)
 		return r;
 	if ((r = ssh_set_newkeys(ssh, MODE_IN)) != 0)
 		return r;
+	if (initial) {
+		/* Remove initial KEX signalling from proposal for rekeying */
+		if ((r = kex_buf2prop(kex->my, NULL, &prop)) != 0)
+			return r;
+		if ((cp = match_filter_denylist(prop[PROPOSAL_KEX_ALGS],
+		    kex->server ?
+		    "ext-info-s,kex-strict-s-v00@openssh.com" :
+		    "ext-info-c,kex-strict-c-v00@openssh.com")) == NULL) {
+			error_f("match_filter_denylist failed");
+			goto fail;
+		}
+		free(prop[PROPOSAL_KEX_ALGS]);
+		prop[PROPOSAL_KEX_ALGS] = cp;
+		if ((r = kex_prop2buf(ssh->kex->my, prop)) != 0) {
+			error_f("kex_prop2buf failed");
+ fail:
+			kex_proposal_free_entries(prop);
+			free(prop);
+			return SSH_ERR_INTERNAL_ERROR;
+		}
+		kex_proposal_free_entries(prop);
+		free(prop);
+	}
 	kex->done = 1;
 	kex->flags &= ~KEX_INITIAL;
 	sshbuf_reset(kex->peer);
-	/* sshbuf_reset(kex->my); */
 	kex->flags &= ~KEX_INIT_SENT;
 	free(kex->name);
 	kex->name = NULL;

--- a/kex.h
+++ b/kex.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: kex.h,v 1.121 2023/12/18 14:45:49 djm Exp $ */
+/* $OpenBSD: kex.h,v 1.122 2024/02/02 00:13:34 djm Exp $ */
 
 /*
  * Copyright (c) 2000, 2001 Markus Friedl.  All rights reserved.
@@ -109,10 +109,10 @@ enum kex_exchange {
 #define KEX_INIT_SENT			0x0001
 #define KEX_INITIAL			0x0002
 #define KEX_HAS_PUBKEY_HOSTBOUND	0x0004
-#define KEX_RSA_SHA2_256_SUPPORTED 	0x0008 /* only set in server for now */
-#define KEX_RSA_SHA2_512_SUPPORTED 	0x0010 /* only set in server for now */
-#define KEX_HAS_PING		 	0x0020
-#define KEX_HAS_EXT_INFO_IN_AUTH 	0x0040
+#define KEX_RSA_SHA2_256_SUPPORTED	0x0008 /* only set in server for now */
+#define KEX_RSA_SHA2_512_SUPPORTED	0x0010 /* only set in server for now */
+#define KEX_HAS_PING			0x0020
+#define KEX_HAS_EXT_INFO_IN_AUTH	0x0040
 
 struct sshenc {
 	char	*name;

--- a/m4/openssh.m4
+++ b/m4/openssh.m4
@@ -20,18 +20,24 @@ char *f2(char *s, ...) {
 	va_end(args);
 	return strdup(ret);
 }
+const char *f3(int s) {
+	return s ? "good" : "gooder";
+}
 int main(int argc, char **argv) {
-	(void)argv;
 	char b[256], *cp;
+	const char *s;
 	/* Some math to catch -ftrapv problems in the toolchain */
 	int i = 123 * argc, j = 456 + argc, k = 789 - argc;
 	float l = i * 2.1;
 	double m = l / 0.5;
 	long long int n = argc * 12345LL, o = 12345LL * (long long int)argc;
+	(void)argv;
 	f(1);
-	snprintf(b, sizeof b, "%d %d %d %f %f %lld %lld\n", i,j,k,l,m,n,o);
+	s = f3(f(2));
+	snprintf(b, sizeof b, "%d %d %d %f %f %lld %lld %s\n", i,j,k,l,m,n,o,s);
 	if (write(1, b, 0) == -1) exit(0);
-	cp = f2("%d %d %d %f %f %lld %lld\n", i,j,k,l,m,n,o);
+	cp = f2("%d %d %d %f %f %lld %lld %s\n", i,j,k,l,m,n,o,s);
+	if (write(1, cp, 0) == -1) exit(0);
 	free(cp);
 	/*
 	 * Test fallthrough behaviour.  clang 10's -Wimplicit-fallthrough does

--- a/metrics.c
+++ b/metrics.c
@@ -253,7 +253,7 @@ metrics_write_binn_object(struct tcp_info *data, struct binn_struct *binnobj) {
  * the object will not necessarily have all of the elements. If it's empty it
  * current just spits out 0. This isn't optimal as 0 can also be a valid value */
 void
-metrics_read_binn_object (void *binnobj, char **output) {
+metrics_read_binn_object (void *binnobj, char *output) {
 	int len = 0;
 	int buflen = 1023;
 	int kernel_version = 0;
@@ -264,7 +264,7 @@ metrics_read_binn_object (void *binnobj, char **output) {
 	kernel_version = binn_object_uint32(binnobj, "kernel_version");
 
 	/* base set of metrics */
-	len = snprintf(*output, buflen, "%d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d",
+	len = snprintf(output, buflen, "%d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d",
 		       binn_object_uint8(binnobj, "tcpi_state"),
 		       binn_object_uint8(binnobj, "tcpi_ca_state"),
 		       binn_object_uint8(binnobj, "tcpi_retransmits"),
@@ -305,28 +305,28 @@ metrics_read_binn_object (void *binnobj, char **output) {
 	 * the remote kernel version. Only necessary under linux*/
 #ifdef __linux__
 	if (kernel_version >= KERNEL_VERSION(3,15,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %llu, %llu",
+		len += snprintf(output+len, (buflen-len), ", %llu, %llu",
 				binn_object_uint64(binnobj, "tcpi_max_pacing_rate"),
 				binn_object_uint64(binnobj, "tcpi_pacing_rate")
 			);
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,1,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %llu, %llu",
+		len += snprintf(output+len, (buflen-len), ", %llu, %llu",
 				binn_object_uint64(binnobj, "tcpi_bytes_acked"),
 				binn_object_uint64(binnobj, "tcpi_bytes_received")
 			);
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,2,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %d, %d",
+		len += snprintf(output+len, (buflen-len), ", %d, %d",
 				binn_object_uint32(binnobj, "tcpi_segs_in"),
 				binn_object_uint32(binnobj, "tcpi_segs_out")
 			);
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,6,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %d, %d, %d, %d",
+		len += snprintf(output+len, (buflen-len), ", %d, %d, %d, %d",
 				binn_object_uint32(binnobj, "tcpi_notsent_bytes"),
 				binn_object_uint32(binnobj, "tcpi_min_rtt"),
 				binn_object_uint32(binnobj, "tcpi_data_segs_in"),
@@ -335,14 +335,14 @@ metrics_read_binn_object (void *binnobj, char **output) {
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,9,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %d, %llu",
+		len += snprintf(output+len, (buflen-len), ", %d, %llu",
 				binn_object_uint8(binnobj, "tcpi_delivery_rate_app_limited"),
 				binn_object_uint64(binnobj, "tcpi_delivery_rate")
 			);
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,10,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %llu, %llu, %llu",
+		len += snprintf(output+len, (buflen-len), ", %llu, %llu, %llu",
 				binn_object_uint64(binnobj, "tcpi_busy_time"),
 				binn_object_uint64(binnobj, "tcpi_sndbuf_limited"),
 				binn_object_uint64(binnobj, "tcpi_rwnd_limited")
@@ -350,14 +350,14 @@ metrics_read_binn_object (void *binnobj, char **output) {
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,18,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %d, %d",
+		len += snprintf(output+len, (buflen-len), ", %d, %d",
 				binn_object_uint32(binnobj, "tcpi_delivered"),
 				binn_object_uint32(binnobj, "tcpi_delivered_ce")
 			);
 	}
 
 	if (kernel_version >= KERNEL_VERSION(4,19,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %llu, %llu, %d, %d",
+		len += snprintf(output+len, (buflen-len), ", %llu, %llu, %d, %d",
 				binn_object_uint64(binnobj, "tcpi_bytes_sent"),
 				binn_object_uint64(binnobj, "tcpi_bytes_retrans"),
 				binn_object_uint32(binnobj, "tcpi_dsack_dups"),
@@ -366,14 +366,14 @@ metrics_read_binn_object (void *binnobj, char **output) {
 	}
 
 	if (kernel_version >= KERNEL_VERSION(5,4,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %d, %d",
+		len += snprintf(output+len, (buflen-len), ", %d, %d",
 				binn_object_uint32(binnobj, "tcpi_snd_wnd"),
 				binn_object_uint32(binnobj, "tcpi_rcv_ooopack")
 			);
 	}
 
 	if (kernel_version >= KERNEL_VERSION(5,5,0)) {
-		len += snprintf(*output+len, (buflen-len), ", %d",
+		len += snprintf(output+len, (buflen-len), ", %d",
 				binn_object_uint8(binnobj, "tcpi_fastopen_client_fail")
 			);
 	}

--- a/metrics.h
+++ b/metrics.h
@@ -38,7 +38,7 @@ typedef struct tcp_info {
 #endif
 
 void metrics_write_binn_object(struct tcp_info *, struct binn_struct *);
-void metrics_read_binn_object(void *, char **);
+void metrics_read_binn_object(void *, char *);
 void metrics_print_header(FILE *, char *, int);
 
 

--- a/misc.c
+++ b/misc.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: misc.c,v 1.189 2023/10/12 03:36:32 djm Exp $ */
+/* $OpenBSD: misc.c,v 1.190 2024/03/04 02:16:11 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  * Copyright (c) 2005-2020 Damien Miller.  All rights reserved.
@@ -2640,6 +2640,19 @@ opt_array_append(const char *file, const int line, const char *directive,
     char ***array, u_int *lp, const char *s)
 {
 	opt_array_append2(file, line, directive, array, NULL, lp, s, 0);
+}
+
+void
+opt_array_free2(char **array, int **iarray, u_int l)
+{
+	u_int i;
+
+	if (array == NULL || l == 0)
+		return;
+	for (i = 0; i < l; i++)
+		free(array[i]);
+	free(array);
+	free(iarray);
 }
 
 sshsig_t

--- a/misc.h
+++ b/misc.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: misc.h,v 1.106 2023/10/11 22:42:26 djm Exp $ */
+/* $OpenBSD: misc.h,v 1.107 2024/03/04 02:16:11 djm Exp $ */
 
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
@@ -204,6 +204,7 @@ void	opt_array_append(const char *file, const int line,
 void	opt_array_append2(const char *file, const int line,
 	    const char *directive, char ***array, int **iarray, u_int *lp,
 	    const char *s, int i);
+void	opt_array_free2(char **array, int **iarray, u_int l);
 
 struct timespec;
 void ptimeout_init(struct timespec *pt);

--- a/nchan.c
+++ b/nchan.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: nchan.c,v 1.74 2022/02/01 23:32:51 djm Exp $ */
+/* $OpenBSD: nchan.c,v 1.75 2024/02/01 02:37:33 djm Exp $ */
 /*
  * Copyright (c) 1999, 2000, 2001, 2002 Markus Friedl.  All rights reserved.
  *
@@ -349,7 +349,7 @@ chan_is_dead(struct ssh *ssh, Channel *c, int do_send)
 	if (c->flags & CHAN_LOCAL) {
 		debug2("channel %d: is dead (local)", c->self);
 		return 1;
-	}		
+	}
 	if (!(c->flags & CHAN_CLOSE_SENT)) {
 		if (do_send) {
 			chan_send_close2(ssh, c);

--- a/openbsd-compat/getopt.h
+++ b/openbsd-compat/getopt.h
@@ -33,6 +33,14 @@
 #ifndef _GETOPT_H_
 #define _GETOPT_H_
 
+#ifndef __THROW
+# if defined __cplusplus
+#  define __THROW throw()
+# else
+#  define __THROW
+# endif
+#endif
+
 /*
  * GNU-like getopt_long() and 4.4BSD getsubopt()/optreset extensions
  */
@@ -63,8 +71,8 @@ int	 getopt_long_only(int, char * const *, const char *,
 
 #ifndef _GETOPT_DEFINED_
 #define _GETOPT_DEFINED_
-int	 getopt(int, char * const *, const char *);
-int	 getsubopt(char **, char * const *, char **);
+int	 getopt(int, char * const *, const char *) __THROW;
+int	 getsubopt(char **, char * const *, char **) __THROW;
 
 extern   char *optarg;                  /* getopt(3) external variables */
 extern   int opterr;

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -48,6 +48,14 @@
 #include "blf.h"
 #include "fnmatch.h"
 
+#ifndef __THROW
+# if defined __cplusplus
+#  define __THROW throw()
+# else
+#  define __THROW
+# endif
+#endif
+
 #if defined(HAVE_LOGIN_CAP) && !defined(HAVE_LOGIN_GETPWCLASS)
 # include <login_cap.h>
 # define login_getpwclass(pw) login_getclass(pw->pw_class)
@@ -187,7 +195,7 @@ int getgrouplist(const char *, gid_t, gid_t *, int *);
 #endif
 
 #if !defined(HAVE_GETOPT) || !defined(HAVE_GETOPT_OPTRESET)
-int BSDgetopt(int argc, char * const *argv, const char *opts);
+int BSDgetopt(int argc, char * const *argv, const char *opts) __THROW;
 #include "openbsd-compat/getopt.h"
 #endif
 

--- a/readconf.c
+++ b/readconf.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: readconf.c,v 1.383 2023/10/12 02:18:18 djm Exp $ */
+/* $OpenBSD: readconf.c,v 1.386 2024/03/04 04:13:18 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -905,6 +905,20 @@ parse_token(const char *cp, const char *filename, int linenum,
 	return oBadOption;
 }
 
+static void
+free_canon_cnames(struct allowed_cname *cnames, u_int n)
+{
+	u_int i;
+
+	if (cnames == NULL || n == 0)
+		return;
+	for (i = 0; i < n; i++) {
+		free(cnames[i].source_list);
+		free(cnames[i].target_list);
+	}
+	free(cnames);
+}
+
 /* Multistate option parsing */
 struct multistate {
 	char *key;
@@ -1047,21 +1061,24 @@ process_config_line_depth(Options *options, struct passwd *pw, const char *host,
 {
 	char *str, **charptr, *endofnumber, *keyword, *arg, *arg2, *p;
 	char **cpptr, ***cppptr, fwdarg[256];
-	u_int i, *uintptr, uvalue, max_entries = 0;
+	u_int i, *uintptr, max_entries = 0;
 	int r, oactive, negated, opcode, *intptr, value, value2, cmdline = 0;
-	int remotefwd, dynamicfwd, ca_only = 0;
+	int remotefwd, dynamicfwd, ca_only = 0, found = 0;
 	LogLevel *log_level_ptr;
 	SyslogFacility *log_facility_ptr;
 	long long val64;
 	size_t len;
 	struct Forward fwd;
 	const struct multistate *multistate_ptr;
-	struct allowed_cname *cname;
 	glob_t gl;
 	const char *errstr;
 	char **oav = NULL, **av;
 	int oac = 0, ac;
 	int ret = -1;
+	struct allowed_cname *cnames = NULL;
+	u_int ncnames = 0;
+	char **strs = NULL; /* string array arguments; freed implicitly */
+	u_int nstrs = 0;
 
 	if (activep == NULL) { /* We are processing a command line directive */
 		cmdline = 1;
@@ -1734,14 +1751,13 @@ parse_pubkey_algos:
 	case oPermitRemoteOpen:
 		uintptr = &options->num_permitted_remote_opens;
 		cppptr = &options->permitted_remote_opens;
-		uvalue = *uintptr;	/* modified later */
-		i = 0;
+		found = *uintptr == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			arg2 = xstrdup(arg);
 			/* Allow any/none only in first position */
 			if (strcasecmp(arg, "none") == 0 ||
 			    strcasecmp(arg, "any") == 0) {
-				if (i > 0 || ac > 0) {
+				if (nstrs > 0 || ac > 0) {
 					error("%s line %d: keyword %s \"%s\" "
 					    "argument must appear alone.",
 					    filename, linenum, keyword, arg);
@@ -1767,17 +1783,20 @@ parse_pubkey_algos:
 					    lookup_opcode_name(opcode));
 				}
 			}
-			if (*activep && uvalue == 0) {
-				opt_array_append(filename, linenum,
-				    lookup_opcode_name(opcode),
-				    cppptr, uintptr, arg2);
-			}
+			opt_array_append(filename, linenum,
+			    lookup_opcode_name(opcode),
+			    &strs, &nstrs, arg2);
 			free(arg2);
-			i++;
 		}
-		if (i == 0)
+		if (nstrs == 0)
 			fatal("%s line %d: missing %s specification",
 			    filename, linenum, lookup_opcode_name(opcode));
+		if (found && *activep) {
+			*cppptr = strs;
+			*uintptr = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
+		}
 		break;
 
 	case oClearAllForwardings:
@@ -1895,12 +1914,14 @@ parse_pubkey_algos:
 		goto parse_int;
 
 	case oSendEnv:
+		/* XXX appends to list; doesn't respect first-match-wins */
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0' || strchr(arg, '=') != NULL) {
 				error("%s line %d: Invalid environment name.",
 				    filename, linenum);
 				goto out;
 			}
+			found = 1;
 			if (!*activep)
 				continue;
 			if (*arg == '-') {
@@ -1912,27 +1933,38 @@ parse_pubkey_algos:
 			    lookup_opcode_name(opcode),
 			    &options->send_env, &options->num_send_env, arg);
 		}
+		if (!found) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
 		break;
 
 	case oSetEnv:
-		value = options->num_setenv;
+		found = options->num_setenv == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (strchr(arg, '=') == NULL) {
 				error("%s line %d: Invalid SetEnv.",
 				    filename, linenum);
 				goto out;
 			}
-			if (!*activep || value != 0)
-				continue;
-			if (lookup_setenv_in_list(arg, options->setenv,
-			    options->num_setenv) != NULL) {
+			if (lookup_setenv_in_list(arg, strs, nstrs) != NULL) {
 				debug2("%s line %d: ignoring duplicate env "
 				    "name \"%.64s\"", filename, linenum, arg);
 				continue;
 			}
 			opt_array_append(filename, linenum,
 			    lookup_opcode_name(opcode),
-			    &options->setenv, &options->num_setenv, arg);
+			    &strs, &nstrs, arg);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->setenv = strs;
+			options->num_setenv = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2141,52 +2173,46 @@ parse_pubkey_algos:
 		goto parse_flag;
 
 	case oCanonicalDomains:
-		value = options->num_canonical_domains != 0;
-		i = 0;
+		found = options->num_canonical_domains == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
-			if (*arg == '\0') {
-				error("%s line %d: keyword %s empty argument",
-				    filename, linenum, keyword);
-				goto out;
-			}
 			/* Allow "none" only in first position */
 			if (strcasecmp(arg, "none") == 0) {
-				if (i > 0 || ac > 0) {
+				if (nstrs > 0 || ac > 0) {
 					error("%s line %d: keyword %s \"none\" "
 					    "argument must appear alone.",
 					    filename, linenum, keyword);
 					goto out;
 				}
 			}
-			i++;
 			if (!valid_domain(arg, 1, &errstr)) {
 				error("%s line %d: %s", filename, linenum,
 				    errstr);
 				goto out;
 			}
-			if (!*activep || value)
-				continue;
-			if (options->num_canonical_domains >=
-			    MAX_CANON_DOMAINS) {
-				error("%s line %d: too many hostname suffixes.",
-				    filename, linenum);
-				goto out;
-			}
-			options->canonical_domains[
-			    options->num_canonical_domains++] = xstrdup(arg);
+			opt_array_append(filename, linenum, keyword,
+			    &strs, &nstrs, arg);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->canonical_domains = strs;
+			options->num_canonical_domains = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
 	case oCanonicalizePermittedCNAMEs:
-		value = options->num_permitted_cnames != 0;
-		i = 0;
+		found = options->num_permitted_cnames == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			/*
 			 * Either 'none' (only in first position), '*' for
 			 * everything or 'list:list'
 			 */
 			if (strcasecmp(arg, "none") == 0) {
-				if (i > 0 || ac > 0) {
+				if (ncnames > 0 || ac > 0) {
 					error("%s line %d: keyword %s \"none\" "
 					    "argument must appear alone.",
 					    filename, linenum, keyword);
@@ -2207,20 +2233,23 @@ parse_pubkey_algos:
 				*arg2 = '\0';
 				arg2++;
 			}
-			i++;
-			if (!*activep || value)
-				continue;
-			if (options->num_permitted_cnames >=
-			    MAX_CANON_DOMAINS) {
-				error("%s line %d: too many permitted CNAMEs.",
-				    filename, linenum);
-				goto out;
-			}
-			cname = options->permitted_cnames +
-			    options->num_permitted_cnames++;
-			cname->source_list = xstrdup(arg);
-			cname->target_list = xstrdup(arg2);
+			cnames = xrecallocarray(cnames, ncnames, ncnames + 1,
+			    sizeof(*cnames));
+			cnames[ncnames].source_list = xstrdup(arg);
+			cnames[ncnames].target_list = xstrdup(arg2);
+			ncnames++;
 		}
+		if (ncnames == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->permitted_cnames = cnames;
+			options->num_permitted_cnames = ncnames;
+			cnames = NULL; /* transferred */
+			ncnames = 0;
+		}
+		/* un-transferred cnames is cleaned up before exit */
 		break;
 
 	case oCanonicalizeHostname:
@@ -2401,12 +2430,11 @@ parse_pubkey_algos:
 		break;
 
 	case oChannelTimeout:
-		uvalue = options->num_channel_timeouts;
-		i = 0;
+		found = options->num_channel_timeouts == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			/* Allow "none" only in first position */
 			if (strcasecmp(arg, "none") == 0) {
-				if (i > 0 || ac > 0) {
+				if (nstrs > 0 || ac > 0) {
 					error("%s line %d: keyword %s \"none\" "
 					    "argument must appear alone.",
 					    filename, linenum, keyword);
@@ -2417,11 +2445,18 @@ parse_pubkey_algos:
 				fatal("%s line %d: invalid channel timeout %s",
 				    filename, linenum, arg);
 			}
-			if (!*activep || uvalue != 0)
-				continue;
 			opt_array_append(filename, linenum, keyword,
-			    &options->channel_timeouts,
-			    &options->num_channel_timeouts, arg);
+			    &strs, &nstrs, arg);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->channel_timeouts = strs;
+			options->num_channel_timeouts = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2453,6 +2488,8 @@ parse_pubkey_algos:
 	/* success */
 	ret = 0;
  out:
+	free_canon_cnames(cnames, ncnames);
+	opt_array_free2(strs, NULL, nstrs);
 	argv_free(oav, oac);
 	return ret;
 }
@@ -2794,7 +2831,9 @@ fill_default_options(Options * options)
 		add_identity_file(options, "~/",
 		    _PATH_SSH_CLIENT_ID_ED25519_SK, 0);
 		add_identity_file(options, "~/", _PATH_SSH_CLIENT_ID_XMSS, 0);
+#ifdef WITH_DSA
 		add_identity_file(options, "~/", _PATH_SSH_CLIENT_ID_DSA, 0);
+#endif
 	}
 	if (options->escape_char == -1)
 		options->escape_char = '~';

--- a/readconf.h
+++ b/readconf.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: readconf.h,v 1.154 2023/10/12 02:18:18 djm Exp $ */
+/* $OpenBSD: readconf.h,v 1.156 2024/03/04 02:16:11 djm Exp $ */
 
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
@@ -90,7 +90,7 @@ typedef struct {
 	char   *sk_provider; /* Security key provider */
 	int	verify_host_key_dns;	/* Verify host key using DNS */
 
-	int     num_identity_files;	/* Number of files for RSA/DSA identities. */
+	int     num_identity_files;	/* Number of files for identities. */
 	char   *identity_files[SSH_MAX_IDENTITY_FILES];
 	int    identity_file_userprovided[SSH_MAX_IDENTITY_FILES];
 	struct sshkey *identity_keys[SSH_MAX_IDENTITY_FILES];
@@ -167,12 +167,12 @@ typedef struct {
 	int	proxy_use_fdpass;
 
 	int	num_canonical_domains;
-	char	*canonical_domains[MAX_CANON_DOMAINS];
+	char	**canonical_domains;
 	int	canonicalize_hostname;
 	int	canonicalize_max_dots;
 	int	canonicalize_fallback_local;
 	int	num_permitted_cnames;
-	struct allowed_cname permitted_cnames[MAX_CANON_DOMAINS];
+	struct allowed_cname *permitted_cnames;
 
 	char	*revoked_host_keys;
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -1,4 +1,4 @@
-#	$OpenBSD: Makefile,v 1.131 2023/12/18 14:50:08 djm Exp $
+#	$OpenBSD: Makefile,v 1.133 2024/01/11 04:50:28 djm Exp $
 
 tests:		prep file-tests t-exec unit
 
@@ -156,48 +156,67 @@ TEST_SSH_SSHKEYGEN?=ssh-keygen
 CPPFLAGS=-I..
 
 t1:
-	${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/rsa_ssh2.prv | diff - ${.CURDIR}/rsa_openssh.prv
-	tr '\n' '\r' <${.CURDIR}/rsa_ssh2.prv > ${.OBJDIR}/rsa_ssh2_cr.prv
-	${TEST_SSH_SSHKEYGEN} -if ${.OBJDIR}/rsa_ssh2_cr.prv | diff - ${.CURDIR}/rsa_openssh.prv
-	awk '{print $$0 "\r"}' ${.CURDIR}/rsa_ssh2.prv > ${.OBJDIR}/rsa_ssh2_crnl.prv
-	${TEST_SSH_SSHKEYGEN} -if ${.OBJDIR}/rsa_ssh2_crnl.prv | diff - ${.CURDIR}/rsa_openssh.prv
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-rsa" ; then \
+		${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/rsa_ssh2.prv | diff - ${.CURDIR}/rsa_openssh.prv ; \
+		tr '\n' '\r' <${.CURDIR}/rsa_ssh2.prv > ${.OBJDIR}/rsa_ssh2_cr.prv ; \
+		${TEST_SSH_SSHKEYGEN} -if ${.OBJDIR}/rsa_ssh2_cr.prv | diff - ${.CURDIR}/rsa_openssh.prv ; \
+		awk '{print $$0 "\r"}' ${.CURDIR}/rsa_ssh2.prv > ${.OBJDIR}/rsa_ssh2_crnl.prv ; \
+		${TEST_SSH_SSHKEYGEN} -if ${.OBJDIR}/rsa_ssh2_crnl.prv | diff - ${.CURDIR}/rsa_openssh.prv ; \
+	fi
 
 t2:
-	cat ${.CURDIR}/rsa_openssh.prv > $(OBJ)/t2.out
-	chmod 600 $(OBJ)/t2.out
-	${TEST_SSH_SSHKEYGEN} -yf $(OBJ)/t2.out | diff - ${.CURDIR}/rsa_openssh.pub
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-rsa" ; then \
+		cat ${.CURDIR}/rsa_openssh.prv > $(OBJ)/t2.out ; \
+		chmod 600 $(OBJ)/t2.out ; \
+		${TEST_SSH_SSHKEYGEN} -yf $(OBJ)/t2.out | diff - ${.CURDIR}/rsa_openssh.pub ; \
+	fi
 
 t3:
-	${TEST_SSH_SSHKEYGEN} -ef ${.CURDIR}/rsa_openssh.pub >$(OBJ)/t3.out
-	${TEST_SSH_SSHKEYGEN} -if $(OBJ)/t3.out | diff - ${.CURDIR}/rsa_openssh.pub
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-rsa" ; then \
+		${TEST_SSH_SSHKEYGEN} -ef ${.CURDIR}/rsa_openssh.pub >$(OBJ)/t3.out ; \
+		${TEST_SSH_SSHKEYGEN} -if $(OBJ)/t3.out | diff - ${.CURDIR}/rsa_openssh.pub ; \
+	fi
 
 t4:
-	${TEST_SSH_SSHKEYGEN} -E md5 -lf ${.CURDIR}/rsa_openssh.pub |\
-		awk '{print $$2}' | diff - ${.CURDIR}/t4.ok
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-rsa" ; then \
+		${TEST_SSH_SSHKEYGEN} -E md5 -lf ${.CURDIR}/rsa_openssh.pub |\
+			awk '{print $$2}' | diff - ${.CURDIR}/t4.ok ; \
+	fi
 
 t5:
-	${TEST_SSH_SSHKEYGEN} -Bf ${.CURDIR}/rsa_openssh.pub |\
-		awk '{print $$2}' | diff - ${.CURDIR}/t5.ok
-
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-rsa" ; then \
+		${TEST_SSH_SSHKEYGEN} -Bf ${.CURDIR}/rsa_openssh.pub |\
+			awk '{print $$2}' | diff - ${.CURDIR}/t5.ok ; \
+	fi
 t6:
-	${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/dsa_ssh2.prv > $(OBJ)/t6.out1
-	${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/dsa_ssh2.pub > $(OBJ)/t6.out2
-	chmod 600 $(OBJ)/t6.out1
-	${TEST_SSH_SSHKEYGEN} -yf $(OBJ)/t6.out1 | diff - $(OBJ)/t6.out2
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-dss" ; then \
+		${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/dsa_ssh2.prv > $(OBJ)/t6.out1 ; \
+		${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/dsa_ssh2.pub > $(OBJ)/t6.out2 ; \
+		chmod 600 $(OBJ)/t6.out1 ; \
+		${TEST_SSH_SSHKEYGEN} -yf $(OBJ)/t6.out1 | diff - $(OBJ)/t6.out2 ; \
+	fi
 
 $(OBJ)/t7.out:
-	${TEST_SSH_SSHKEYGEN} -q -t rsa -N '' -f $@
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-dss" ; then \
+		${TEST_SSH_SSHKEYGEN} -q -t rsa -N '' -f $@ ; \
+	fi
 
 t7: $(OBJ)/t7.out
-	${TEST_SSH_SSHKEYGEN} -lf $(OBJ)/t7.out > /dev/null
-	${TEST_SSH_SSHKEYGEN} -Bf $(OBJ)/t7.out > /dev/null
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-dss" ; then \
+		${TEST_SSH_SSHKEYGEN} -lf $(OBJ)/t7.out > /dev/null ; \
+		${TEST_SSH_SSHKEYGEN} -Bf $(OBJ)/t7.out > /dev/null ; \
+	fi
 
 $(OBJ)/t8.out:
-	${TEST_SSH_SSHKEYGEN} -q -t dsa -N '' -f $@
+	set -xe ; if ssh -Q key | grep -q "^ssh-dss" ; then \
+		${TEST_SSH_SSHKEYGEN} -q -t dsa -N '' -f $@ ; \
+	fi
 
 t8: $(OBJ)/t8.out
-	${TEST_SSH_SSHKEYGEN} -lf $(OBJ)/t8.out > /dev/null
-	${TEST_SSH_SSHKEYGEN} -Bf $(OBJ)/t8.out > /dev/null
+	set -xe ; if ssh -Q key | grep -q "^ssh-dss" ; then \
+		${TEST_SSH_SSHKEYGEN} -lf $(OBJ)/t8.out > /dev/null ; \
+		${TEST_SSH_SSHKEYGEN} -Bf $(OBJ)/t8.out > /dev/null ; \
+	fi
 
 $(OBJ)/t9.out:
 	! ${TEST_SSH_SSH} -Q key-plain | grep ecdsa >/dev/null || \
@@ -218,8 +237,10 @@ t10: $(OBJ)/t10.out
 	${TEST_SSH_SSHKEYGEN} -Bf $(OBJ)/t10.out > /dev/null
 
 t11:
-	${TEST_SSH_SSHKEYGEN} -E sha256 -lf ${.CURDIR}/rsa_openssh.pub |\
-		awk '{print $$2}' | diff - ${.CURDIR}/t11.ok
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-dss" ; then \
+		${TEST_SSH_SSHKEYGEN} -E sha256 -lf ${.CURDIR}/rsa_openssh.pub |\
+			awk '{print $$2}' | diff - ${.CURDIR}/t11.ok ; \
+	fi
 
 $(OBJ)/t12.out:
 	${TEST_SSH_SSHKEYGEN} -q -t ed25519 -N '' -C 'test-comment-1234' -f $@

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -208,12 +208,12 @@ t7: $(OBJ)/t7.out
 	fi
 
 $(OBJ)/t8.out:
-	set -xe ; if ssh -Q key | grep -q "^ssh-dss" ; then \
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-dss" ; then \
 		${TEST_SSH_SSHKEYGEN} -q -t dsa -N '' -f $@ ; \
 	fi
 
 t8: $(OBJ)/t8.out
-	set -xe ; if ssh -Q key | grep -q "^ssh-dss" ; then \
+	set -xe ; if ${TEST_SSH_SSH} -Q key | grep -q "^ssh-dss" ; then \
 		${TEST_SSH_SSHKEYGEN} -lf $(OBJ)/t8.out > /dev/null ; \
 		${TEST_SSH_SSHKEYGEN} -Bf $(OBJ)/t8.out > /dev/null ; \
 	fi

--- a/regress/channel-timeout.sh
+++ b/regress/channel-timeout.sh
@@ -1,9 +1,32 @@
-#	$OpenBSD: channel-timeout.sh,v 1.1 2023/01/06 08:07:39 djm Exp $
+#	$OpenBSD: channel-timeout.sh,v 1.2 2024/01/09 22:19:36 djm Exp $
 #	Placed in the Public Domain.
 
 tid="channel timeout"
 
 # XXX not comprehensive. Still need -R -L agent X11 forwarding + interactive
+
+rm -f $OBJ/finished.* $OBJ/mux.*
+
+MUXPATH=$OBJ/mux.$$
+open_mux() {
+	${SSH} -nNfM -oControlPath=$MUXPATH -F $OBJ/ssh_proxy "$@" somehost ||
+	    fatal "open mux failed"
+	test -e $MUXPATH || fatal "mux socket $MUXPATH not established"
+}
+
+close_mux() {
+	test -e $MUXPATH || fatal "mux socket $MUXPATH missing"
+	${SSH} -qF $OBJ/ssh_proxy -oControlPath=$MUXPATH -O exit somehost ||
+	    fatal "could not terminate mux process"
+	for x in 1 2 3 4 5 6 7 8 9 10 ; do
+		test -e $OBJ/mux && break
+		sleep 1
+	done
+	test -e $MUXPATH && fatal "mux did not clean up"
+}
+mux_client() {
+	${SSH} -F $OBJ/ssh_proxy -oControlPath=$MUXPATH somehost "$@"
+}
 
 rm -f $OBJ/sshd_proxy.orig 
 cp $OBJ/sshd_proxy $OBJ/sshd_proxy.orig
@@ -24,6 +47,15 @@ if [ $r -ne 255 ]; then
 	fail "ssh returned unexpected error code $r"
 fi
 
+verbose "command long timeout"
+(cat $OBJ/sshd_proxy.orig ; echo "ChannelTimeout session:command=60") \
+	> $OBJ/sshd_proxy
+${SSH} -F $OBJ/ssh_proxy somehost "exit 23"
+r=$?
+if [ $r -ne 23 ]; then
+	fail "ssh returned unexpected error code $r"
+fi
+
 verbose "command wildcard timeout"
 (cat $OBJ/sshd_proxy.orig ; echo "ChannelTimeout session:*=1") \
 	> $OBJ/sshd_proxy
@@ -40,6 +72,45 @@ ${SSH} -F $OBJ/ssh_proxy somehost "sleep 5 ; exit 23"
 r=$?
 if [ $r -ne 23 ]; then
 	fail "ssh failed"
+fi
+
+if config_defined DISABLE_FD_PASSING ; then
+	verbose "skipping multiplexing tests"
+else
+	verbose "multiplexed command timeout"
+	(cat $OBJ/sshd_proxy.orig ; echo "ChannelTimeout session:command=1") \
+		> $OBJ/sshd_proxy
+	open_mux
+	mux_client "sleep 5 ; exit 23"
+	r=$?
+	if [ $r -ne 255 ]; then
+		fail "ssh returned unexpected error code $r"
+	fi
+	close_mux
+
+	verbose "irrelevant multiplexed command timeout"
+	(cat $OBJ/sshd_proxy.orig ; echo "ChannelTimeout session:shell=1") \
+		> $OBJ/sshd_proxy
+	open_mux
+	mux_client "sleep 5 ; exit 23"
+	r=$?
+	if [ $r -ne 23 ]; then
+		fail "ssh returned unexpected error code $r"
+	fi
+	close_mux
+
+	verbose "global command timeout"
+	(cat $OBJ/sshd_proxy.orig ; echo "ChannelTimeout global=10") \
+		> $OBJ/sshd_proxy
+	open_mux
+	mux_client "sleep 1 ; echo ok ; sleep 1; echo ok; sleep 60; touch $OBJ/finished.1" >/dev/null &
+	mux_client "sleep 60 ; touch $OBJ/finished.2" >/dev/null &
+	mux_client "sleep 2 ; touch $OBJ/finished.3" >/dev/null &
+	wait
+	test -f $OBJ/finished.1 && fail "first mux process completed"
+	test -f $OBJ/finished.2 && fail "second mux process completed"
+	test -f $OBJ/finished.3 || fail "third mux process did not complete"
+	close_mux
 fi
 
 # Set up a "slow sftp server" that sleeps before executing the real one.
@@ -88,4 +159,3 @@ if [ $r -ne 0 ]; then
 	fail "sftp failed"
 fi
 cmp $DATA $COPY || fail "corrupted copy"
-

--- a/regress/misc/fuzz-harness/Makefile
+++ b/regress/misc/fuzz-harness/Makefile
@@ -1,10 +1,10 @@
 # NB. libssh and libopenbsd-compat should be built with the same sanitizer opts.
-CC=clang-11
-CXX=clang++-11
+CC=clang-16
+CXX=clang++-16
 FUZZ_FLAGS=-fsanitize=address,fuzzer -fno-omit-frame-pointer
-FUZZ_LIBS=-lFuzzer
+FUZZ_LIBS=-L/usr/lib/llvm-16/lib -lFuzzer
 
-CXXFLAGS=-O2 -g -Wall -Wextra -Wno-unused-parameter -I ../../.. $(FUZZ_FLAGS)
+CXXFLAGS=-O2 -g -Wall -Wextra -Wno-unused-parameter -Wno-exceptions -I ../../.. $(FUZZ_FLAGS)
 CFLAGS=$(CXXFLAGS)
 LDFLAGS=-L ../../.. -L ../../../openbsd-compat -g $(FUZZ_FLAGS)
 LIBS=-lssh -lopenbsd-compat -lmd -lcrypto -lfido2 -lcbor $(FUZZ_LIBS)

--- a/regress/misc/fuzz-harness/agent_fuzz_helper.c
+++ b/regress/misc/fuzz-harness/agent_fuzz_helper.c
@@ -175,3 +175,10 @@ test_one(const uint8_t* s, size_t slen)
 	cleanup_idtab();
 	cleanup_sockettab();
 }
+
+int
+pkcs11_make_cert(const struct sshkey *priv,
+    const struct sshkey *certpub, struct sshkey **certprivp)
+{
+	return -1; /* XXX */
+}

--- a/regress/multiplex.sh
+++ b/regress/multiplex.sh
@@ -8,8 +8,7 @@ tid="connection multiplexing"
 
 trace "will use ProxyCommand $proxycmd"
 if config_defined DISABLE_FD_PASSING ; then
-	echo "skipped (not supported on this platform)"
-	exit 0
+	skip "not supported on this platform (FD passing disabled)"
 fi
 
 P=3301  # test port

--- a/regress/putty-ciphers.sh
+++ b/regress/putty-ciphers.sh
@@ -1,24 +1,47 @@
-#	$OpenBSD: putty-ciphers.sh,v 1.11 2021/09/01 03:16:06 dtucker Exp $
+#	$OpenBSD: putty-ciphers.sh,v 1.13 2024/02/09 08:56:59 dtucker Exp $
 #	Placed in the Public Domain.
 
 tid="putty ciphers"
 
-if test "x$REGRESS_INTEROP_PUTTY" != "xyes" ; then
-	skip "putty interop tests not enabled"
-fi
+puttysetup
 
-# Re-enable ssh-rsa on older PuTTY versions.
-oldver="`${PLINK} --version | awk '/plink: Release/{if ($3<0.76)print "yes"}'`"
-if [ "x$oldver" = "xyes" ]; then
-	echo "HostKeyAlgorithms +ssh-rsa" >> ${OBJ}/sshd_proxy
-	echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> ${OBJ}/sshd_proxy
-fi
+cp ${OBJ}/sshd_proxy ${OBJ}/sshd_proxy_bak
 
-for c in aes 3des aes128-ctr aes192-ctr aes256-ctr chacha20 ; do
-	verbose "$tid: cipher $c"
+# Since there doesn't seem to be a way to set MACs on the PuTTY client side,
+# we force each in turn on the server side, omitting the ones PuTTY doesn't
+# support.  Grepping the binary is pretty janky, but AFAIK there's no way to
+# query for supported algos.
+macs=""
+for m in `${SSH} -Q MACs`; do
+	if strings "${PLINK}" | grep -E "^${m}$" >/dev/null; then
+		macs="${macs} ${m}"
+	else
+		trace "omitting unsupported MAC ${m}"
+	fi
+done
+
+ciphers=""
+for c in `${SSH} -Q Ciphers`; do
+	if strings "${PLINK}" | grep -E "^${c}$" >/dev/null; then
+		ciphers="${ciphers} ${c}"
+	else
+		trace "omitting unsupported cipher ${c}"
+	fi
+done
+
+for c in default $ciphers; do
+    for m in default ${macs}; do
+	verbose "$tid: cipher $c mac $m"
 	cp ${OBJ}/.putty/sessions/localhost_proxy \
 	    ${OBJ}/.putty/sessions/cipher_$c
-	echo "Cipher=$c" >> ${OBJ}/.putty/sessions/cipher_$c
+	if [ "${c}" != "default" ]; then
+		echo "Cipher=$c" >> ${OBJ}/.putty/sessions/cipher_$c
+	fi
+
+	cp ${OBJ}/sshd_proxy_bak ${OBJ}/sshd_proxy
+	if [ "${m}" != "default" ]; then
+		echo "MACs $m" >> ${OBJ}/sshd_proxy
+	fi
 
 	rm -f ${COPY}
 	env HOME=$PWD ${PLINK} -load cipher_$c -batch -i ${OBJ}/putty.rsa2 \
@@ -27,6 +50,6 @@ for c in aes 3des aes128-ctr aes192-ctr aes256-ctr chacha20 ; do
 		fail "ssh cat $DATA failed"
 	fi
 	cmp ${DATA} ${COPY}		|| fail "corrupted copy"
+    done
 done
 rm -f ${COPY}
-

--- a/regress/putty-ciphers.sh
+++ b/regress/putty-ciphers.sh
@@ -31,6 +31,12 @@ done
 
 for c in default $ciphers; do
     for m in default ${macs}; do
+	# none is a valid cipher in hpnssh but it
+	# causes the tests to fail so skip it
+	# cjr - 3/5/2024
+	if [ "${m}" = "none" ]; then
+	    continue
+	fi
 	verbose "$tid: cipher $c mac $m"
 	cp ${OBJ}/.putty/sessions/localhost_proxy \
 	    ${OBJ}/.putty/sessions/cipher_$c

--- a/regress/putty-kex.sh
+++ b/regress/putty-kex.sh
@@ -1,28 +1,36 @@
-#	$OpenBSD: putty-kex.sh,v 1.9 2021/09/01 03:16:06 dtucker Exp $
+#	$OpenBSD: putty-kex.sh,v 1.11 2024/02/09 08:56:59 dtucker Exp $
 #	Placed in the Public Domain.
 
 tid="putty KEX"
 
-if test "x$REGRESS_INTEROP_PUTTY" != "xyes" ; then
-	skip "putty interop tests not enabled"
-fi
+puttysetup
 
-# Re-enable ssh-rsa on older PuTTY versions.
-oldver="`${PLINK} --version | awk '/plink: Release/{if ($3<0.76)print "yes"}'`"
-if [ "x$oldver" = "xyes" ]; then
-	echo "HostKeyAlgorithms +ssh-rsa" >> ${OBJ}/sshd_proxy
-	echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> ${OBJ}/sshd_proxy
-fi
+cp ${OBJ}/sshd_proxy ${OBJ}/sshd_proxy_bak
 
-for k in dh-gex-sha1 dh-group1-sha1 dh-group14-sha1 ecdh ; do
-	verbose "$tid: kex $k"
-	cp ${OBJ}/.putty/sessions/localhost_proxy \
-	    ${OBJ}/.putty/sessions/kex_$k
-	echo "KEX=$k" >> ${OBJ}/.putty/sessions/kex_$k
+# Enable group1, which PuTTY now disables by default
+echo "KEX=dh-group1-sha1" >>${OBJ}/.putty/sessions/localhost_proxy
 
-	env HOME=$PWD ${PLINK} -load kex_$k -batch -i ${OBJ}/putty.rsa2 true
-	if [ $? -ne 0 ]; then
-		fail "KEX $k failed"
+# Grepping algos out of the binary is pretty janky, but AFAIK there's no way
+# to query supported algos.
+kex=""
+for k in `$SSH -Q kex`; do
+	if strings "${PLINK}" | grep -E "^${k}$" >/dev/null; then
+		kex="${kex} ${k}"
+	else
+		trace "omitting unsupported KEX ${k}"
 	fi
 done
 
+for k in ${kex}; do
+	verbose "$tid: kex $k"
+	cp ${OBJ}/sshd_proxy_bak ${OBJ}/sshd_proxy
+	echo "KexAlgorithms ${k}" >>${OBJ}/sshd_proxy
+
+	env HOME=$PWD ${PLINK} -v -load localhost_proxy -batch -i ${OBJ}/putty.rsa2 true \
+	    2>${OBJ}/log/putty-kex-$k.log
+	if [ $? -ne 0 ]; then
+		fail "KEX $k failed"
+	fi
+	kexmsg=`grep -E '^Doing.* key exchange' ${OBJ}/log/putty-kex-$k.log`
+	trace putty: ${kexmsg}
+done

--- a/regress/putty-transfer.sh
+++ b/regress/putty-transfer.sh
@@ -1,18 +1,9 @@
-#	$OpenBSD: putty-transfer.sh,v 1.11 2021/09/01 03:16:06 dtucker Exp $
+#	$OpenBSD: putty-transfer.sh,v 1.12 2024/02/09 08:47:42 dtucker Exp $
 #	Placed in the Public Domain.
 
 tid="putty transfer data"
 
-if test "x$REGRESS_INTEROP_PUTTY" != "xyes" ; then
-	skip "putty interop tests not enabled"
-fi
-
-# Re-enable ssh-rsa on older PuTTY versions.
-oldver="`${PLINK} --version | awk '/plink: Release/{if ($3<0.76)print "yes"}'`"
-if [ "x$oldver" = "xyes" ]; then
-	echo "HostKeyAlgorithms +ssh-rsa" >> ${OBJ}/sshd_proxy
-	echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> ${OBJ}/sshd_proxy
-fi
+puttysetup
 
 if [ "`${SSH} -Q compression`" = "none" ]; then
 	comp="0"

--- a/regress/test-exec.sh
+++ b/regress/test-exec.sh
@@ -1,4 +1,4 @@
-#	$OpenBSD: test-exec.sh,v 1.105 2023/10/31 04:15:40 dtucker Exp $
+#	$OpenBSD: test-exec.sh,v 1.108 2024/03/08 11:34:10 dtucker Exp $
 #	Placed in the Public Domain.
 
 #SUDO=sudo
@@ -103,6 +103,9 @@ DROPBEAR=/usr/local/bin/dropbear
 DBCLIENT=/usr/local/bin/dbclient
 DROPBEARKEY=/usr/local/bin/dropbearkey
 DROPBEARCONVERT=/usr/local/bin/dropbearconvert
+
+# So we can override this in Portable.
+TEST_SHELL="${TEST_SHELL:-/bin/sh}"
 
 # Tools used by multiple tests
 NC=$OBJ/netcat
@@ -761,7 +764,11 @@ case "$SCRIPT" in
 *)		REGRESS_INTEROP_PUTTY=no ;;
 esac
 
-if test "$REGRESS_INTEROP_PUTTY" = "yes" ; then
+puttysetup() {
+	if test "x$REGRESS_INTEROP_PUTTY" != "xyes" ; then
+		skip "putty interop tests not enabled"
+	fi
+
 	mkdir -p ${OBJ}/.putty
 
 	# Add a PuTTY key to authorized_keys
@@ -794,9 +801,24 @@ if test "$REGRESS_INTEROP_PUTTY" = "yes" ; then
 	echo "ProxyTelnetCommand=${OBJ}/sshd-log-wrapper.sh -i -f $OBJ/sshd_proxy" >> ${OBJ}/.putty/sessions/localhost_proxy
 	echo "ProxyLocalhost=1" >> ${OBJ}/.putty/sessions/localhost_proxy
 
+	PUTTYVER="`${PLINK} --version | awk '/plink: Release/{print $3}'`"
+	PUTTYMINORVER="`echo ${PUTTYVER} | cut -f2 -d.`"
+	verbose "plink version ${PUTTYVER} minor ${PUTTYMINORVER}"
+
+	# Re-enable ssh-rsa on older PuTTY versions since they don't do newer
+	# key types.
+	if [ "$PUTTYMINORVER" -lt "76" ]; then
+		echo "HostKeyAlgorithms +ssh-rsa" >> ${OBJ}/sshd_proxy
+		echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> ${OBJ}/sshd_proxy
+	fi
+
+	if [ "$PUTTYMINORVER" -le "64" ]; then
+		echo "KexAlgorithms +diffie-hellman-group14-sha1" \
+		    >>${OBJ}/sshd_proxy
+	fi
 	PUTTYDIR=${OBJ}/.putty
 	export PUTTYDIR
-fi
+}
 
 REGRESS_INTEROP_DROPBEAR=no
 if test -x "$DROPBEARKEY" -a -x "$DBCLIENT" -a -x "$DROPBEARCONVERT"; then

--- a/regress/unittests/Makefile.inc
+++ b/regress/unittests/Makefile.inc
@@ -1,4 +1,4 @@
-#	$OpenBSD: Makefile.inc,v 1.15 2023/09/24 08:14:13 claudio Exp $
+#	$OpenBSD: Makefile.inc,v 1.16 2024/01/11 01:45:58 djm Exp $
 
 .include <bsd.own.mk>
 .include <bsd.obj.mk>
@@ -13,6 +13,11 @@ TEST_ENV?=		MALLOC_OPTIONS=${MALLOC_OPTIONS}
 
 # XXX detect from ssh binary?
 OPENSSL?=	yes
+DSAKEY?=	yes
+
+.if (${DSAKEY:L} == "yes")
+CFLAGS+=	-DWITH_DSA
+.endif
 
 .if (${OPENSSL:L} == "yes")
 CFLAGS+=	-DWITH_OPENSSL

--- a/regress/unittests/hostkeys/test_iterate.c
+++ b/regress/unittests/hostkeys/test_iterate.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: test_iterate.c,v 1.8 2021/12/14 21:25:27 deraadt Exp $ */
+/* 	$OpenBSD: test_iterate.c,v 1.9 2024/01/11 01:45:58 djm Exp $ */
 /*
  * Regress test for hostfile.h hostkeys_foreach()
  *
@@ -94,6 +94,11 @@ check(struct hostkey_foreach_line *l, void *_ctx)
 	    expected->no_parse_keytype == KEY_ECDSA)
 		skip = 1;
 #endif /* OPENSSL_HAS_ECC */
+#ifndef WITH_DSA
+	if (expected->l.keytype == KEY_DSA ||
+	    expected->no_parse_keytype == KEY_DSA)
+		skip = 1;
+#endif
 #ifndef WITH_OPENSSL
 	if (expected->l.keytype == KEY_DSA ||
 	    expected->no_parse_keytype == KEY_DSA ||
@@ -155,6 +160,10 @@ prepare_expected(struct expected *expected, size_t n)
 		if (expected[i].l.keytype == KEY_ECDSA)
 			continue;
 #endif /* OPENSSL_HAS_ECC */
+#ifndef WITH_DSA
+		if (expected[i].l.keytype == KEY_DSA)
+			continue;
+#endif
 #ifndef WITH_OPENSSL
 		switch (expected[i].l.keytype) {
 		case KEY_RSA:

--- a/regress/unittests/kex/test_kex.c
+++ b/regress/unittests/kex/test_kex.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: test_kex.c,v 1.6 2021/12/14 21:25:27 deraadt Exp $ */
+/* 	$OpenBSD: test_kex.c,v 1.7 2024/01/11 01:45:58 djm Exp $ */
 /*
  * Regress test KEX
  *
@@ -179,7 +179,9 @@ do_kex(char *kex)
 {
 #ifdef WITH_OPENSSL
 	do_kex_with_key(kex, KEY_RSA, 2048);
+#ifdef WITH_DSA
 	do_kex_with_key(kex, KEY_DSA, 1024);
+#endif
 #ifdef OPENSSL_HAS_ECC
 	do_kex_with_key(kex, KEY_ECDSA, 256);
 #endif /* OPENSSL_HAS_ECC */

--- a/regress/unittests/sshkey/test_file.c
+++ b/regress/unittests/sshkey/test_file.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: test_file.c,v 1.10 2021/12/14 21:25:27 deraadt Exp $ */
+/* 	$OpenBSD: test_file.c,v 1.11 2024/01/11 01:45:58 djm Exp $ */
 /*
  * Regress test for sshkey.h key management API
  *
@@ -165,6 +165,7 @@ sshkey_file_tests(void)
 
 	sshkey_free(k1);
 
+#ifdef WITH_DSA
 	TEST_START("parse DSA from private");
 	buf = load_file("dsa_1");
 	ASSERT_INT_EQ(sshkey_parse_private_fileblob(buf, "", &k1, NULL), 0);
@@ -255,6 +256,7 @@ sshkey_file_tests(void)
 	TEST_DONE();
 
 	sshkey_free(k1);
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("parse ECDSA from private");

--- a/regress/unittests/sshkey/test_fuzz.c
+++ b/regress/unittests/sshkey/test_fuzz.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: test_fuzz.c,v 1.13 2021/12/14 21:25:27 deraadt Exp $ */
+/* 	$OpenBSD: test_fuzz.c,v 1.14 2024/01/11 01:45:58 djm Exp $ */
 /*
  * Fuzz tests for key parsing
  *
@@ -160,6 +160,7 @@ sshkey_fuzz_tests(void)
 	fuzz_cleanup(fuzz);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("fuzz DSA private");
 	buf = load_file("dsa_1");
 	fuzz = fuzz_begin(FUZZ_BASE64, sshbuf_mutable_ptr(buf),
@@ -203,6 +204,7 @@ sshkey_fuzz_tests(void)
 	sshbuf_free(fuzzed);
 	fuzz_cleanup(fuzz);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("fuzz ECDSA private");
@@ -288,6 +290,7 @@ sshkey_fuzz_tests(void)
 	sshkey_free(k1);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("fuzz DSA public");
 	buf = load_file("dsa_1");
 	ASSERT_INT_EQ(sshkey_parse_private_fileblob(buf, "", &k1, NULL), 0);
@@ -301,6 +304,7 @@ sshkey_fuzz_tests(void)
 	public_fuzz(k1);
 	sshkey_free(k1);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("fuzz ECDSA public");
@@ -358,6 +362,7 @@ sshkey_fuzz_tests(void)
 	sshkey_free(k1);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("fuzz DSA sig");
 	buf = load_file("dsa_1");
 	ASSERT_INT_EQ(sshkey_parse_private_fileblob(buf, "", &k1, NULL), 0);
@@ -365,6 +370,7 @@ sshkey_fuzz_tests(void)
 	sig_fuzz(k1, NULL);
 	sshkey_free(k1);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("fuzz ECDSA sig");

--- a/regress/unittests/sshkey/test_sshkey.c
+++ b/regress/unittests/sshkey/test_sshkey.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: test_sshkey.c,v 1.23 2023/01/04 22:48:57 tb Exp $ */
+/* 	$OpenBSD: test_sshkey.c,v 1.24 2024/01/11 01:45:58 djm Exp $ */
 /*
  * Regress test for sshkey.h key management API
  *
@@ -180,14 +180,14 @@ get_private(const char *n)
 void
 sshkey_tests(void)
 {
-	struct sshkey *k1, *k2, *k3, *kf;
+	struct sshkey *k1 = NULL, *k2 = NULL, *k3 = NULL, *kf = NULL;
 #ifdef WITH_OPENSSL
-	struct sshkey *k4, *kr, *kd;
+	struct sshkey *k4 = NULL, *kr = NULL, *kd = NULL;
 #ifdef OPENSSL_HAS_ECC
-	struct sshkey *ke;
+	struct sshkey *ke = NULL;
 #endif /* OPENSSL_HAS_ECC */
 #endif /* WITH_OPENSSL */
-	struct sshbuf *b;
+	struct sshbuf *b = NULL;
 
 	TEST_START("new invalid");
 	k1 = sshkey_new(-42);
@@ -208,12 +208,14 @@ sshkey_tests(void)
 	sshkey_free(k1);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("new/free KEY_DSA");
 	k1 = sshkey_new(KEY_DSA);
 	ASSERT_PTR_NE(k1, NULL);
 	ASSERT_PTR_NE(k1->dsa, NULL);
 	sshkey_free(k1);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("new/free KEY_ECDSA");
@@ -245,12 +247,14 @@ sshkey_tests(void)
 	ASSERT_PTR_EQ(k1, NULL);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("generate KEY_DSA wrong bits");
 	ASSERT_INT_EQ(sshkey_generate(KEY_DSA, 2048, &k1),
 	    SSH_ERR_KEY_LENGTH);
 	ASSERT_PTR_EQ(k1, NULL);
 	sshkey_free(k1);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("generate KEY_ECDSA wrong bits");
@@ -273,6 +277,7 @@ sshkey_tests(void)
 	ASSERT_INT_EQ(BN_num_bits(rsa_n(kr)), 1024);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("generate KEY_DSA");
 	ASSERT_INT_EQ(sshkey_generate(KEY_DSA, 1024, &kd), 0);
 	ASSERT_PTR_NE(kd, NULL);
@@ -280,6 +285,7 @@ sshkey_tests(void)
 	ASSERT_PTR_NE(dsa_g(kd), NULL);
 	ASSERT_PTR_NE(dsa_priv_key(kd), NULL);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("generate KEY_ECDSA");
@@ -317,6 +323,7 @@ sshkey_tests(void)
 	sshkey_free(k1);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("demote KEY_DSA");
 	ASSERT_INT_EQ(sshkey_from_private(kd, &k1), 0);
 	ASSERT_PTR_NE(k1, NULL);
@@ -331,6 +338,7 @@ sshkey_tests(void)
 	ASSERT_INT_EQ(sshkey_equal(kd, k1), 1);
 	sshkey_free(k1);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("demote KEY_ECDSA");
@@ -381,9 +389,6 @@ sshkey_tests(void)
 #ifdef WITH_OPENSSL
 	ASSERT_INT_EQ(sshkey_generate(KEY_RSA, 1024, &k1), 0);
 	ASSERT_INT_EQ(sshkey_equal(kr, k1), 0);
-	sshkey_free(k1);
-	ASSERT_INT_EQ(sshkey_generate(KEY_DSA, 1024, &k1), 0);
-	ASSERT_INT_EQ(sshkey_equal(kd, k1), 0);
 	sshkey_free(k1);
 #ifdef OPENSSL_HAS_ECC
 	ASSERT_INT_EQ(sshkey_generate(KEY_ECDSA, 256, &k1), 0);
@@ -479,6 +484,7 @@ sshkey_tests(void)
 	sshkey_free(k2);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("sign and verify DSA");
 	k1 = get_private("dsa_1");
 	ASSERT_INT_EQ(sshkey_load_public(test_data_file("dsa_2.pub"), &k2,
@@ -487,6 +493,7 @@ sshkey_tests(void)
 	sshkey_free(k1);
 	sshkey_free(k2);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("sign and verify ECDSA");

--- a/regress/unittests/sshsig/tests.c
+++ b/regress/unittests/sshsig/tests.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: tests.c,v 1.3 2021/12/14 21:25:27 deraadt Exp $ */
+/* 	$OpenBSD: tests.c,v 1.4 2024/01/11 01:45:59 djm Exp $ */
 /*
  * Regress test for sshbuf.h buffer API
  *
@@ -103,9 +103,11 @@ tests(void)
 	check_sig("rsa.pub", "rsa.sig", msg, namespace);
 	TEST_DONE();
 
+#ifdef WITH_DSA
 	TEST_START("check DSA signature");
 	check_sig("dsa.pub", "dsa.sig", msg, namespace);
 	TEST_DONE();
+#endif
 
 #ifdef OPENSSL_HAS_ECC
 	TEST_START("check ECDSA signature");

--- a/servconf.c
+++ b/servconf.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: servconf.c,v 1.403 2023/10/11 22:42:26 djm Exp $ */
+/* $OpenBSD: servconf.c,v 1.405 2024/03/04 02:16:11 djm Exp $ */
 /*
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
  *                    All rights reserved
@@ -1324,12 +1324,12 @@ process_server_config_line_depth(ServerOptions *options, char *line,
     struct include_list *includes)
 {
 	char *str, ***chararrayptr, **charptr, *arg, *arg2, *p, *keyword;
-	int cmdline = 0, *intptr, value, value2, n, port, oactive, r, found;
-	int ca_only = 0;
+	int cmdline = 0, *intptr, value, value2, n, port, oactive, r;
+	int ca_only = 0, found = 0;
 	SyslogFacility *log_facility_ptr;
 	LogLevel *log_level_ptr;
 	ServerOpCodes opcode;
-	u_int i, *uintptr, uvalue, flags = 0;
+	u_int i, *uintptr, flags = 0;
 	size_t len;
 	long long val64;
 	const struct multistate *multistate_ptr;
@@ -1339,6 +1339,8 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 	char **oav = NULL, **av;
 	int oac = 0, ac;
 	int ret = -1;
+	char **strs = NULL; /* string array arguments; freed implicitly */
+	u_int nstrs = 0;
 
 	/* Strip trailing whitespace. Allow \f (form feed) at EOL only */
 	if ((len = strlen(line)) == 0)
@@ -1822,7 +1824,6 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 
 	case sLogVerbose:
 		found = options->num_log_verbose == 0;
-		i = 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0') {
 				error("%s line %d: keyword %s empty argument",
@@ -1831,19 +1832,25 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			}
 			/* Allow "none" only in first position */
 			if (strcasecmp(arg, "none") == 0) {
-				if (i > 0 || ac > 0) {
+				if (nstrs > 0 || ac > 0) {
 					error("%s line %d: keyword %s \"none\" "
 					    "argument must appear alone.",
 					    filename, linenum, keyword);
 					goto out;
 				}
 			}
-			i++;
-			if (!found || !*activep)
-				continue;
 			opt_array_append(filename, linenum, keyword,
-			    &options->log_verbose, &options->num_log_verbose,
-			    arg);
+			    &strs, &nstrs, arg);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->log_verbose = strs;
+			options->num_log_verbose = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -1869,15 +1876,21 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		chararrayptr = &options->allow_users;
 		uintptr = &options->num_allow_users;
  parse_allowdenyusers:
+		/* XXX appends to list; doesn't respect first-match-wins */
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0' ||
 			    match_user(NULL, NULL, NULL, arg) == -1)
 				fatal("%s line %d: invalid %s pattern: \"%s\"",
 				    filename, linenum, keyword, arg);
+			found = 1;
 			if (!*activep)
 				continue;
 			opt_array_append(filename, linenum, keyword,
 			    chararrayptr, uintptr, arg);
+		}
+		if (!found) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
 		}
 		break;
 
@@ -1889,15 +1902,21 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 	case sAllowGroups:
 		chararrayptr = &options->allow_groups;
 		uintptr = &options->num_allow_groups;
+		/* XXX appends to list; doesn't respect first-match-wins */
  parse_allowdenygroups:
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0')
 				fatal("%s line %d: empty %s pattern",
 				    filename, linenum, keyword);
+			found = 1;
 			if (!*activep)
 				continue;
 			opt_array_append(filename, linenum, keyword,
 			    chararrayptr, uintptr, arg);
+		}
+		if (!found) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
 		}
 		break;
 
@@ -1992,7 +2011,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		arg = argv_assemble(1, &arg); /* quote command correctly */
 		arg2 = argv_assemble(ac, av); /* rest of command */
 		xasprintf(&options->subsystem_args[options->num_subsystems],
-		    "%s %s", arg, arg2);
+		    "%s%s%s", arg, *arg2 == '\0' ? "" : " ", arg2);
 		free(arg2);
 		argv_consume(&ac);
 		options->num_subsystems++;
@@ -2082,7 +2101,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 	 * AuthorizedKeysFile	/etc/ssh_keys/%u
 	 */
 	case sAuthorizedKeysFile:
-		uvalue = options->num_authkeys_files;
+		found = options->num_authkeys_files == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0') {
 				error("%s line %d: keyword %s empty argument",
@@ -2090,12 +2109,19 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 				goto out;
 			}
 			arg2 = tilde_expand_filename(arg, getuid());
-			if (*activep && uvalue == 0) {
-				opt_array_append(filename, linenum, keyword,
-				    &options->authorized_keys_files,
-				    &options->num_authkeys_files, arg2);
-			}
+			opt_array_append(filename, linenum, keyword,
+			    &strs, &nstrs, arg2);
 			free(arg2);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->authorized_keys_files = strs;
+			options->num_authkeys_files = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2122,34 +2148,47 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		goto parse_int;
 
 	case sAcceptEnv:
+		/* XXX appends to list; doesn't respect first-match-wins */
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0' || strchr(arg, '=') != NULL)
 				fatal("%s line %d: Invalid environment name.",
 				    filename, linenum);
+			found = 1;
 			if (!*activep)
 				continue;
 			opt_array_append(filename, linenum, keyword,
 			    &options->accept_env, &options->num_accept_env,
 			    arg);
 		}
+		if (!found) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
 		break;
 
 	case sSetEnv:
-		uvalue = options->num_setenv;
+		found = options->num_setenv == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (*arg == '\0' || strchr(arg, '=') == NULL)
 				fatal("%s line %d: Invalid environment.",
 				    filename, linenum);
-			if (!*activep || uvalue != 0)
-				continue;
-			if (lookup_setenv_in_list(arg, options->setenv,
-			    options->num_setenv) != NULL) {
+			if (lookup_setenv_in_list(arg, strs, nstrs) != NULL) {
 				debug2("%s line %d: ignoring duplicate env "
 				    "name \"%.64s\"", filename, linenum, arg);
 				continue;
 			}
 			opt_array_append(filename, linenum, keyword,
-			    &options->setenv, &options->num_setenv, arg);
+			    &strs, &nstrs, arg);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->setenv = strs;
+			options->num_setenv = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2300,21 +2339,20 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			uintptr = &options->num_permitted_opens;
 			chararrayptr = &options->permitted_opens;
 		}
-		arg = argv_next(&ac, &av);
-		if (!arg || *arg == '\0')
-			fatal("%s line %d: %s missing argument.",
-			    filename, linenum, keyword);
-		uvalue = *uintptr;	/* modified later */
-		if (strcmp(arg, "any") == 0 || strcmp(arg, "none") == 0) {
-			if (*activep && uvalue == 0) {
-				*uintptr = 1;
-				*chararrayptr = xcalloc(1,
-				    sizeof(**chararrayptr));
-				(*chararrayptr)[0] = xstrdup(arg);
+		found = *uintptr == 0;
+		while ((arg = argv_next(&ac, &av)) != NULL) {
+			if (strcmp(arg, "any") == 0 ||
+			    strcmp(arg, "none") == 0) {
+				if (nstrs != 0) {
+					fatal("%s line %d: %s must appear "
+					    "alone on a %s line.",
+					    filename, linenum, arg, keyword);
+				}
+				opt_array_append(filename, linenum, keyword,
+				    &strs, &nstrs, arg);
+				continue;
 			}
-			break;
-		}
-		for (; arg != NULL && *arg != '\0'; arg = argv_next(&ac, &av)) {
+
 			if (opcode == sPermitListen &&
 			    strchr(arg, ':') == NULL) {
 				/*
@@ -2336,11 +2374,19 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 				fatal("%s line %d: %s bad port number",
 				    filename, linenum, keyword);
 			}
-			if (*activep && uvalue == 0) {
-				opt_array_append(filename, linenum, keyword,
-				    chararrayptr, uintptr, arg2);
-			}
+			opt_array_append(filename, linenum, keyword,
+			    &strs, &nstrs, arg2);
 			free(arg2);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: %s missing argument.",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			*chararrayptr = strs;
+			*uintptr = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2466,10 +2512,9 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 	case sAuthenticationMethods:
 		found = options->num_auth_methods == 0;
 		value = 0; /* seen "any" pseudo-method */
-		value2 = 0; /* successfully parsed any method */
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			if (strcmp(arg, "any") == 0) {
-				if (options->num_auth_methods > 0) {
+				if (nstrs > 0) {
 					fatal("%s line %d: \"any\" must "
 					    "appear alone in %s",
 					    filename, linenum, keyword);
@@ -2482,16 +2527,18 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 				fatal("%s line %d: invalid %s method list.",
 				    filename, linenum, keyword);
 			}
-			value2 = 1;
-			if (!found || !*activep)
-				continue;
 			opt_array_append(filename, linenum, keyword,
-			    &options->auth_methods,
-			    &options->num_auth_methods, arg);
+			    &strs, &nstrs, arg);
 		}
-		if (value2 == 0) {
+		if (nstrs == 0) {
 			fatal("%s line %d: no %s specified",
 			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->auth_methods = strs;
+			options->num_auth_methods = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2552,12 +2599,11 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		goto parse_int;
 
 	case sChannelTimeout:
-		uvalue = options->num_channel_timeouts;
-		i = 0;
+		found = options->num_channel_timeouts == 0;
 		while ((arg = argv_next(&ac, &av)) != NULL) {
 			/* Allow "none" only in first position */
 			if (strcasecmp(arg, "none") == 0) {
-				if (i > 0 || ac > 0) {
+				if (nstrs > 0 || ac > 0) {
 					error("%s line %d: keyword %s \"none\" "
 					    "argument must appear alone.",
 					    filename, linenum, keyword);
@@ -2568,11 +2614,18 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 				fatal("%s line %d: invalid channel timeout %s",
 				    filename, linenum, arg);
 			}
-			if (!*activep || uvalue != 0)
-				continue;
 			opt_array_append(filename, linenum, keyword,
-			    &options->channel_timeouts,
-			    &options->num_channel_timeouts, arg);
+			    &strs, &nstrs, arg);
+		}
+		if (nstrs == 0) {
+			fatal("%s line %d: no %s specified",
+			    filename, linenum, keyword);
+		}
+		if (found && *activep) {
+			options->channel_timeouts = strs;
+			options->num_channel_timeouts = nstrs;
+			strs = NULL; /* transferred */
+			nstrs = 0;
 		}
 		break;
 
@@ -2612,6 +2665,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 	/* success */
 	ret = 0;
  out:
+	opt_array_free2(strs, NULL, nstrs);
 	argv_free(oav, oac);
 	return ret;
 }

--- a/session.c
+++ b/session.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: session.c,v 1.336 2023/08/10 23:05:48 djm Exp $ */
+/* $OpenBSD: session.c,v 1.337 2024/02/01 02:37:33 djm Exp $ */
 /*
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
  *                    All rights reserved

--- a/sftp.c
+++ b/sftp.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sftp.c,v 1.236 2023/09/10 23:12:32 djm Exp $ */
+/* $OpenBSD: sftp.c,v 1.237 2024/02/01 02:37:33 djm Exp $ */
 /*
  * Copyright (c) 2001-2004 Damien Miller <djm@openbsd.org>
  *
@@ -177,24 +177,24 @@ struct CMD {
 #define LOCAL	2
 
 static const struct CMD cmds[] = {
-	{ "bye",	I_QUIT,		NOARGS, 	NOARGS	},
-	{ "cd",		I_CHDIR,	REMOTE, 	NOARGS	},
-	{ "chdir",	I_CHDIR,	REMOTE, 	NOARGS	},
-	{ "chgrp",	I_CHGRP,	REMOTE, 	NOARGS	},
-	{ "chmod",	I_CHMOD,	REMOTE, 	NOARGS	},
-	{ "chown",	I_CHOWN,	REMOTE, 	NOARGS	},
-	{ "copy",	I_COPY,		REMOTE, 	LOCAL	},
-	{ "cp",		I_COPY,		REMOTE, 	LOCAL	},
-	{ "df",		I_DF,		REMOTE, 	NOARGS	},
-	{ "dir",	I_LS,		REMOTE, 	NOARGS	},
-	{ "exit",	I_QUIT,		NOARGS, 	NOARGS	},
-	{ "get",	I_GET,		REMOTE, 	LOCAL	},
-	{ "help",	I_HELP,		NOARGS, 	NOARGS	},
+	{ "bye",	I_QUIT,		NOARGS,		NOARGS	},
+	{ "cd",		I_CHDIR,	REMOTE,		NOARGS	},
+	{ "chdir",	I_CHDIR,	REMOTE,		NOARGS	},
+	{ "chgrp",	I_CHGRP,	REMOTE,		NOARGS	},
+	{ "chmod",	I_CHMOD,	REMOTE,		NOARGS	},
+	{ "chown",	I_CHOWN,	REMOTE,		NOARGS	},
+	{ "copy",	I_COPY,		REMOTE,		LOCAL	},
+	{ "cp",		I_COPY,		REMOTE,		LOCAL	},
+	{ "df",		I_DF,		REMOTE,		NOARGS	},
+	{ "dir",	I_LS,		REMOTE,		NOARGS	},
+	{ "exit",	I_QUIT,		NOARGS,		NOARGS	},
+	{ "get",	I_GET,		REMOTE,		LOCAL	},
+	{ "help",	I_HELP,		NOARGS,		NOARGS	},
 	{ "lcd",	I_LCHDIR,	LOCAL,		NOARGS	},
 	{ "lchdir",	I_LCHDIR,	LOCAL,		NOARGS	},
 	{ "lls",	I_LLS,		LOCAL,		NOARGS	},
 	{ "lmkdir",	I_LMKDIR,	LOCAL,		NOARGS	},
-	{ "ln",		I_LINK,		REMOTE, 	REMOTE	},
+	{ "ln",		I_LINK,		REMOTE,		REMOTE	},
 	{ "lpwd",	I_LPWD,		LOCAL,		NOARGS	},
 	{ "ls",		I_LS,		REMOTE,		NOARGS	},
 	{ "lumask",	I_LUMASK,	NOARGS,		NOARGS	},
@@ -203,17 +203,17 @@ static const struct CMD cmds[] = {
 	{ "mput",	I_PUT,		LOCAL,		REMOTE	},
 	{ "progress",	I_PROGRESS,	NOARGS,		NOARGS	},
 	{ "put",	I_PUT,		LOCAL,		REMOTE	},
-	{ "pwd",	I_PWD,		REMOTE, 	NOARGS	},
-	{ "quit",	I_QUIT,		NOARGS, 	NOARGS	},
-	{ "reget",	I_REGET,	REMOTE, 	LOCAL	},
-	{ "rename",	I_RENAME,	REMOTE, 	REMOTE	},
+	{ "pwd",	I_PWD,		REMOTE,		NOARGS	},
+	{ "quit",	I_QUIT,		NOARGS,		NOARGS	},
+	{ "reget",	I_REGET,	REMOTE,		LOCAL	},
+	{ "rename",	I_RENAME,	REMOTE,		REMOTE	},
 	{ "reput",	I_REPUT,	LOCAL,		REMOTE	},
 	{ "rm",		I_RM,		REMOTE,		NOARGS	},
 	{ "rmdir",	I_RMDIR,	REMOTE,		NOARGS	},
 	{ "symlink",	I_SYMLINK,	REMOTE,		REMOTE	},
-	{ "version",	I_VERSION,	NOARGS, 	NOARGS	},
-	{ "!",		I_SHELL,	NOARGS, 	NOARGS	},
-	{ "?",		I_HELP,		NOARGS, 	NOARGS	},
+	{ "version",	I_VERSION,	NOARGS,		NOARGS	},
+	{ "!",		I_SHELL,	NOARGS,		NOARGS	},
+	{ "?",		I_HELP,		NOARGS,		NOARGS	},
 	{ NULL,		-1,		-1,		-1	}
 };
 

--- a/ssh-add.c
+++ b/ssh-add.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh-add.c,v 1.169 2023/12/18 14:46:56 djm Exp $ */
+/* $OpenBSD: ssh-add.c,v 1.172 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -85,7 +85,9 @@ static char *default_files[] = {
 	_PATH_SSH_CLIENT_ID_ED25519,
 	_PATH_SSH_CLIENT_ID_ED25519_SK,
 	_PATH_SSH_CLIENT_ID_XMSS,
+#ifdef WITH_DSA
 	_PATH_SSH_CLIENT_ID_DSA,
+#endif
 	NULL
 };
 
@@ -790,13 +792,17 @@ static void
 usage(void)
 {
 	fprintf(stderr,
+<<<<<<< HEAD
 "usage: hpnssh-add [-cDdKkLlqvXx] [-E fingerprint_hash] [-H hostkey_file]\n"
+=======
+"usage: ssh-add [-CcDdKkLlqvXx] [-E fingerprint_hash] [-H hostkey_file]\n"
+>>>>>>> V_9_7_P1
 "               [-h destination_constraint] [-S provider] [-t life]\n"
 #ifdef WITH_XMSS
 "               [-M maxsign] [-m minleft]\n"
 #endif
 "               [file ...]\n"
-"       ssh-add -s pkcs11\n"
+"       ssh-add -s pkcs11 [-Cv] [certificate ...]\n"
 "       ssh-add -e pkcs11\n"
 "       ssh-add -T pubkey ...\n"
 	);

--- a/ssh-add.c
+++ b/ssh-add.c
@@ -792,12 +792,8 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-<<<<<<< HEAD
-"usage: hpnssh-add [-cDdKkLlqvXx] [-E fingerprint_hash] [-H hostkey_file]\n"
-=======
-"usage: ssh-add [-CcDdKkLlqvXx] [-E fingerprint_hash] [-H hostkey_file]\n"
->>>>>>> V_9_7_P1
-"               [-h destination_constraint] [-S provider] [-t life]\n"
+"usage: hpnssh-add [-CcDdKkLlqvXx] [-E fingerprint_hash] [-H hostkey_file]\n"
+"                  [-h destination_constraint] [-S provider] [-t life]\n"
 #ifdef WITH_XMSS
 "               [-M maxsign] [-m minleft]\n"
 #endif

--- a/ssh-dss.c
+++ b/ssh-dss.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh-dss.c,v 1.49 2023/03/05 05:34:09 dtucker Exp $ */
+/* $OpenBSD: ssh-dss.c,v 1.50 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  *
@@ -25,7 +25,7 @@
 
 #include "includes.h"
 
-#ifdef WITH_OPENSSL
+#if defined(WITH_OPENSSL) && defined(WITH_DSA)
 
 #include <sys/types.h>
 
@@ -453,4 +453,5 @@ const struct sshkey_impl sshkey_dsa_cert_impl = {
 	/* .keybits = */	0,
 	/* .funcs = */		&sshkey_dss_funcs,
 };
-#endif /* WITH_OPENSSL */
+
+#endif /* WITH_OPENSSL && WITH_DSA */

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh-keygen.c,v 1.471 2023/09/04 10:29:58 job Exp $ */
+/* $OpenBSD: ssh-keygen.c,v 1.472 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1994 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -262,10 +262,12 @@ ask_filename(struct passwd *pw, const char *prompt)
 		name = _PATH_SSH_CLIENT_ID_ED25519;
 	else {
 		switch (sshkey_type_from_name(key_type_name)) {
+#ifdef WITH_DSA
 		case KEY_DSA_CERT:
 		case KEY_DSA:
 			name = _PATH_SSH_CLIENT_ID_DSA;
 			break;
+#endif
 #ifdef OPENSSL_HAS_ECC
 		case KEY_ECDSA_CERT:
 		case KEY_ECDSA:
@@ -376,10 +378,12 @@ do_convert_to_pkcs8(struct sshkey *k)
 		if (!PEM_write_RSA_PUBKEY(stdout, k->rsa))
 			fatal("PEM_write_RSA_PUBKEY failed");
 		break;
+#ifdef WITH_DSA
 	case KEY_DSA:
 		if (!PEM_write_DSA_PUBKEY(stdout, k->dsa))
 			fatal("PEM_write_DSA_PUBKEY failed");
 		break;
+#endif
 #ifdef OPENSSL_HAS_ECC
 	case KEY_ECDSA:
 		if (!PEM_write_EC_PUBKEY(stdout, k->ecdsa))
@@ -400,10 +404,12 @@ do_convert_to_pem(struct sshkey *k)
 		if (!PEM_write_RSAPublicKey(stdout, k->rsa))
 			fatal("PEM_write_RSAPublicKey failed");
 		break;
+#ifdef WITH_DSA
 	case KEY_DSA:
 		if (!PEM_write_DSA_PUBKEY(stdout, k->dsa))
 			fatal("PEM_write_DSA_PUBKEY failed");
 		break;
+#endif
 #ifdef OPENSSL_HAS_ECC
 	case KEY_ECDSA:
 		if (!PEM_write_EC_PUBKEY(stdout, k->ecdsa))
@@ -478,8 +484,10 @@ do_convert_private_ssh2(struct sshbuf *b)
 	u_int magic, i1, i2, i3, i4;
 	size_t slen;
 	u_long e;
+#ifdef WITH_DSA
 	BIGNUM *dsa_p = NULL, *dsa_q = NULL, *dsa_g = NULL;
 	BIGNUM *dsa_pub_key = NULL, *dsa_priv_key = NULL;
+#endif
 	BIGNUM *rsa_n = NULL, *rsa_e = NULL, *rsa_d = NULL;
 	BIGNUM *rsa_p = NULL, *rsa_q = NULL, *rsa_iqmp = NULL;
 
@@ -507,10 +515,12 @@ do_convert_private_ssh2(struct sshbuf *b)
 	}
 	free(cipher);
 
-	if (strstr(type, "dsa")) {
-		ktype = KEY_DSA;
-	} else if (strstr(type, "rsa")) {
+	if (strstr(type, "rsa")) {
 		ktype = KEY_RSA;
+#ifdef WITH_DSA
+	} else if (strstr(type, "dsa")) {
+		ktype = KEY_DSA;
+#endif
 	} else {
 		free(type);
 		return NULL;
@@ -520,6 +530,7 @@ do_convert_private_ssh2(struct sshbuf *b)
 	free(type);
 
 	switch (key->type) {
+#ifdef WITH_DSA
 	case KEY_DSA:
 		if ((dsa_p = BN_new()) == NULL ||
 		    (dsa_q = BN_new()) == NULL ||
@@ -539,6 +550,7 @@ do_convert_private_ssh2(struct sshbuf *b)
 			fatal_f("DSA_set0_key failed");
 		dsa_pub_key = dsa_priv_key = NULL; /* transferred */
 		break;
+#endif
 	case KEY_RSA:
 		if ((r = sshbuf_get_u8(b, &e1)) != 0 ||
 		    (e1 < 30 && (r = sshbuf_get_u8(b, &e2)) != 0) ||
@@ -702,12 +714,14 @@ do_convert_from_pkcs8(struct sshkey **k, int *private)
 		(*k)->type = KEY_RSA;
 		(*k)->rsa = EVP_PKEY_get1_RSA(pubkey);
 		break;
+#ifdef WITH_DSA
 	case EVP_PKEY_DSA:
 		if ((*k = sshkey_new(KEY_UNSPEC)) == NULL)
 			fatal("sshkey_new failed");
 		(*k)->type = KEY_DSA;
 		(*k)->dsa = EVP_PKEY_get1_DSA(pubkey);
 		break;
+#endif
 #ifdef OPENSSL_HAS_ECC
 	case EVP_PKEY_EC:
 		if ((*k = sshkey_new(KEY_UNSPEC)) == NULL)
@@ -777,10 +791,12 @@ do_convert_from(struct passwd *pw)
 			fprintf(stdout, "\n");
 	} else {
 		switch (k->type) {
+#ifdef WITH_DSA
 		case KEY_DSA:
 			ok = PEM_write_DSAPrivateKey(stdout, k->dsa, NULL,
 			    NULL, 0, NULL, NULL);
 			break;
+#endif
 #ifdef OPENSSL_HAS_ECC
 		case KEY_ECDSA:
 			ok = PEM_write_ECPrivateKey(stdout, k->ecdsa, NULL,
@@ -3752,9 +3768,11 @@ main(int argc, char **argv)
 			n += do_print_resource_record(pw,
 			    _PATH_HOST_RSA_KEY_FILE, rr_hostname,
 			    print_generic, opts, nopts);
+#ifdef WITH_DSA
 			n += do_print_resource_record(pw,
 			    _PATH_HOST_DSA_KEY_FILE, rr_hostname,
 			    print_generic, opts, nopts);
+#endif
 			n += do_print_resource_record(pw,
 			    _PATH_HOST_ECDSA_KEY_FILE, rr_hostname,
 			    print_generic, opts, nopts);

--- a/ssh-keyscan.c
+++ b/ssh-keyscan.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh-keyscan.c,v 1.153 2023/06/21 05:06:04 djm Exp $ */
+/* $OpenBSD: ssh-keyscan.c,v 1.155 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Copyright 1995, 1996 by David Mazieres <dm@lcs.mit.edu>.
  *
@@ -504,11 +504,11 @@ congreet(int s)
 
 	/*
 	 * Read the server banner as per RFC4253 section 4.2.  The "SSH-"
-	 * protocol identification string may be preceeded by an arbitrarily
+	 * protocol identification string may be preceded by an arbitrarily
 	 * large banner which we must read and ignore.  Loop while reading
 	 * newline-terminated lines until we have one starting with "SSH-".
 	 * The ID string cannot be longer than 255 characters although the
-	 * preceeding banner lines may (in which case they'll be discarded
+	 * preceding banner lines may (in which case they'll be discarded
 	 * in multiple iterations of the outer loop).
 	 */
 	for (;;) {
@@ -791,9 +791,11 @@ main(int argc, char **argv)
 				int type = sshkey_type_from_name(tname);
 
 				switch (type) {
+#ifdef WITH_DSA
 				case KEY_DSA:
 					get_keytypes |= KT_DSA;
 					break;
+#endif
 				case KEY_ECDSA:
 					get_keytypes |= KT_ECDSA;
 					break;

--- a/ssh-keysign.c
+++ b/ssh-keysign.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh-keysign.c,v 1.71 2022/08/01 11:09:26 djm Exp $ */
+/* $OpenBSD: ssh-keysign.c,v 1.73 2024/01/11 01:51:16 djm Exp $ */
 /*
  * Copyright (c) 2002 Markus Friedl.  All rights reserved.
  *
@@ -195,9 +195,14 @@ main(int argc, char **argv)
 	if (fd > 2)
 		close(fd);
 
+	for (i = 0; i < NUM_KEYTYPES; i++)
+		key_fd[i] = -1;
+
 	i = 0;
 	/* XXX This really needs to read sshd_config for the paths */
+#ifdef WITH_DSA
 	key_fd[i++] = open(_PATH_HOST_DSA_KEY_FILE, O_RDONLY);
+#endif
 	key_fd[i++] = open(_PATH_HOST_ECDSA_KEY_FILE, O_RDONLY);
 	key_fd[i++] = open(_PATH_HOST_ED25519_KEY_FILE, O_RDONLY);
 	key_fd[i++] = open(_PATH_HOST_XMSS_KEY_FILE, O_RDONLY);

--- a/ssh.c
+++ b/ssh.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh.c,v 1.599 2023/12/18 14:47:44 djm Exp $ */
+/* $OpenBSD: ssh.c,v 1.600 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -1718,11 +1718,15 @@ tryagain:
 			L_CERT(_PATH_HOST_ECDSA_KEY_FILE, 0);
 			L_CERT(_PATH_HOST_ED25519_KEY_FILE, 1);
 			L_CERT(_PATH_HOST_RSA_KEY_FILE, 2);
+#ifdef WITH_DSA
 			L_CERT(_PATH_HOST_DSA_KEY_FILE, 3);
+#endif
 			L_PUBKEY(_PATH_HOST_ECDSA_KEY_FILE, 4);
 			L_PUBKEY(_PATH_HOST_ED25519_KEY_FILE, 5);
 			L_PUBKEY(_PATH_HOST_RSA_KEY_FILE, 6);
+#ifdef WITH_DSA
 			L_PUBKEY(_PATH_HOST_DSA_KEY_FILE, 7);
+#endif
 			L_CERT(_PATH_HOST_XMSS_KEY_FILE, 8);
 			L_PUBKEY(_PATH_HOST_XMSS_KEY_FILE, 9);
 			if (loaded == 0)

--- a/sshbuf-getput-crypto.c
+++ b/sshbuf-getput-crypto.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: sshbuf-getput-crypto.c,v 1.10 2022/05/25 06:03:44 djm Exp $	*/
+/*	$OpenBSD: sshbuf-getput-crypto.c,v 1.11 2024/02/01 02:37:33 djm Exp $	*/
 /*
  * Copyright (c) 2011 Damien Miller
  *
@@ -123,7 +123,7 @@ sshbuf_get_eckey(struct sshbuf *buf, EC_KEY *v)
 		SSHBUF_ABORT();
 		return SSH_ERR_INTERNAL_ERROR;
 	}
-	return 0;	
+	return 0;
 }
 #endif /* OPENSSL_HAS_ECC */
 

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshconnect.c,v 1.365 2023/11/20 02:50:00 djm Exp $ */
+/* $OpenBSD: sshconnect.c,v 1.366 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -1595,7 +1595,9 @@ show_other_keys(struct hostkeys *hostkeys, struct sshkey *key)
 {
 	int type[] = {
 		KEY_RSA,
+#ifdef WITH_DSA
 		KEY_DSA,
+#endif
 		KEY_ECDSA,
 		KEY_ED25519,
 		KEY_XMSS,

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshconnect2.c,v 1.371 2023/12/18 14:45:49 djm Exp $ */
+/* $OpenBSD: sshconnect2.c,v 1.372 2024/01/08 00:34:34 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  * Copyright (c) 2008 Damien Miller.  All rights reserved.
@@ -229,7 +229,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
     const struct ssh_conn_info *cinfo)
 {
 	char *myproposal[PROPOSAL_MAX];
-	char *s, *all_key, *hkalgs = NULL;
+	char *all_key, *hkalgs = NULL;
 	int r, use_known_hosts_order = 0;
 
 	xxx_host = host;
@@ -257,14 +257,12 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
 		fatal_fr(r, "kex_assemble_namelist");
 	free(all_key);
 
-	if ((s = kex_names_cat(options.kex_algorithms, "ext-info-c")) == NULL)
-		fatal_f("kex_names_cat");
-
 	if (use_known_hosts_order)
 		hkalgs = order_hostkeyalgs(host, hostaddr, port, cinfo);
 
-	kex_proposal_populate_entries(ssh, myproposal, s, options.ciphers,
-	    options.macs, compression_alg_list(options.compression),
+	kex_proposal_populate_entries(ssh, myproposal,
+	    options.kex_algorithms, options.ciphers, options.macs,
+	    compression_alg_list(options.compression),
 	    hkalgs ? hkalgs : options.hostkeyalgorithms);
 
 	free(hkalgs);
@@ -289,13 +287,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
 	ssh->kex->verify_host_key=&verify_host_key_callback;
 
 	ssh_dispatch_run_fatal(ssh, DISPATCH_BLOCK, &ssh->kex->done);
-
-	/* remove ext-info from the KEX proposals for rekeying */
-	free(myproposal[PROPOSAL_KEX_ALGS]);
-	myproposal[PROPOSAL_KEX_ALGS] =
-	    compat_kex_proposal(ssh, options.kex_algorithms);
-	if ((r = kex_prop2buf(ssh->kex->my, myproposal)) != 0)
-		fatal_r(r, "kex_prop2buf");
+	kex_proposal_free_entries(myproposal);
 
 #ifdef DEBUG_KEXDH
 	/* send 1st encrypted/maced/compressed message */
@@ -305,7 +297,6 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
 	    (r = ssh_packet_write_wait(ssh)) != 0)
 		fatal_fr(r, "send packet");
 #endif
-	kex_proposal_free_entries(myproposal);
 }
 
 /*

--- a/sshd.c
+++ b/sshd.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshd.c,v 1.601 2023/12/18 14:45:49 djm Exp $ */
+/* $OpenBSD: sshd.c,v 1.602 2024/01/08 00:34:34 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -2455,6 +2455,7 @@ do_ssh2_kex(struct ssh *ssh)
 	kex->sign = sshd_hostkey_sign;
 
 	ssh_dispatch_run_fatal(ssh, DISPATCH_BLOCK, &kex->done);
+	kex_proposal_free_entries(myproposal);
 
 #ifdef DEBUG_KEXDH
 	/* send 1st encrypted/maced/compressed message */
@@ -2464,7 +2465,6 @@ do_ssh2_kex(struct ssh *ssh)
 	    (r = ssh_packet_write_wait(ssh)) != 0)
 		fatal_fr(r, "send test");
 #endif
-	kex_proposal_free_entries(myproposal);
 	debug("KEX done");
 }
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshkey.c,v 1.140 2023/10/16 08:40:00 dtucker Exp $ */
+/* $OpenBSD: sshkey.c,v 1.142 2024/01/11 01:45:36 djm Exp $ */
 /*
  * Copyright (c) 2000, 2001 Markus Friedl.  All rights reserved.
  * Copyright (c) 2008 Alexander von Gernler.  All rights reserved.
@@ -121,8 +121,10 @@ extern const struct sshkey_impl sshkey_rsa_sha256_impl;
 extern const struct sshkey_impl sshkey_rsa_sha256_cert_impl;
 extern const struct sshkey_impl sshkey_rsa_sha512_impl;
 extern const struct sshkey_impl sshkey_rsa_sha512_cert_impl;
+# ifdef WITH_DSA
 extern const struct sshkey_impl sshkey_dss_impl;
 extern const struct sshkey_impl sshkey_dsa_cert_impl;
+# endif
 #endif /* WITH_OPENSSL */
 #ifdef WITH_XMSS
 extern const struct sshkey_impl sshkey_xmss_impl;
@@ -152,8 +154,10 @@ const struct sshkey_impl * const keyimpls[] = {
 	&sshkey_ecdsa_sk_webauthn_impl,
 #  endif /* ENABLE_SK */
 # endif /* OPENSSL_HAS_ECC */
+# ifdef WITH_DSA
 	&sshkey_dss_impl,
 	&sshkey_dsa_cert_impl,
+# endif
 	&sshkey_rsa_impl,
 	&sshkey_rsa_cert_impl,
 	&sshkey_rsa_sha256_impl,
@@ -1929,7 +1933,7 @@ sshkey_from_blob_internal(struct sshbuf *b, struct sshkey **keyp,
 		goto out;
 	}
 	if (sshkey_type_is_cert(type)) {
-		/* Skip nonce that preceeds all certificates */
+		/* Skip nonce that precedes all certificates */
 		if (sshbuf_get_string_direct(b, NULL, NULL) != 0) {
 			ret = SSH_ERR_INVALID_FORMAT;
 			goto out;
@@ -3241,6 +3245,7 @@ sshkey_private_to_blob_pem_pkcs8(struct sshkey *key, struct sshbuf *buf,
 		goto out;
 
 	switch (key->type) {
+#ifdef WITH_DSA
 	case KEY_DSA:
 		if (format == SSHKEY_PRIVATE_PEM) {
 			success = PEM_write_bio_DSAPrivateKey(bio, key->dsa,
@@ -3249,6 +3254,7 @@ sshkey_private_to_blob_pem_pkcs8(struct sshkey *key, struct sshbuf *buf,
 			success = EVP_PKEY_set1_DSA(pkey, key->dsa);
 		}
 		break;
+#endif
 #ifdef OPENSSL_HAS_ECC
 	case KEY_ECDSA:
 		if (format == SSHKEY_PRIVATE_PEM) {
@@ -3477,6 +3483,7 @@ sshkey_parse_private_pem_fileblob(struct sshbuf *blob, int type,
 		}
 		if ((r = sshkey_check_rsa_length(prv, 0)) != 0)
 			goto out;
+#ifdef WITH_DSA
 	} else if (EVP_PKEY_base_id(pk) == EVP_PKEY_DSA &&
 	    (type == KEY_UNSPEC || type == KEY_DSA)) {
 		if ((prv = sshkey_new(KEY_UNSPEC)) == NULL) {
@@ -3487,6 +3494,7 @@ sshkey_parse_private_pem_fileblob(struct sshbuf *blob, int type,
 		prv->type = KEY_DSA;
 #ifdef DEBUG_PK
 		DSA_print_fp(stderr, prv->dsa, 8);
+#endif
 #endif
 #ifdef OPENSSL_HAS_ECC
 	} else if (EVP_PKEY_base_id(pk) == EVP_PKEY_EC &&

--- a/sshsig.c
+++ b/sshsig.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshsig.c,v 1.34 2023/12/08 09:18:39 markus Exp $ */
+/* $OpenBSD: sshsig.c,v 1.35 2024/03/08 22:16:32 djm Exp $ */
 /*
  * Copyright (c) 2019 Google LLC
  *
@@ -746,7 +746,7 @@ parse_principals_key_and_options(const char *path, u_long linenum, char *line,
 		*keyp = NULL;
 
 	cp = line;
-	cp = cp + strspn(cp, " \t"); /* skip leading whitespace */
+	cp = cp + strspn(cp, " \t\n\r"); /* skip leading whitespace */
 	if (*cp == '#' || *cp == '\0')
 		return SSH_ERR_KEY_NOT_FOUND; /* blank or all-comment line */
 

--- a/version.h
+++ b/version.h
@@ -3,5 +3,5 @@
 #define SSH_VERSION	"OpenSSH_9.7"
 
 #define SSH_PORTABLE	"p1"
-#define SSH_HPN         "-hpn18.3.1"
+#define SSH_HPN         "-hpn18.4.0"
 #define SSH_RELEASE	SSH_VERSION SSH_PORTABLE SSH_HPN

--- a/version.h
+++ b/version.h
@@ -3,5 +3,5 @@
 #define SSH_VERSION	"OpenSSH_9.6"
 
 #define SSH_PORTABLE	"p1"
-#define SSH_HPN         "-hpn18.3.0"
+#define SSH_HPN         "-hpn18.3.1"
 #define SSH_RELEASE	SSH_VERSION SSH_PORTABLE SSH_HPN

--- a/version.h
+++ b/version.h
@@ -1,6 +1,6 @@
-/* $OpenBSD: version.h,v 1.100 2023/12/18 14:48:44 djm Exp $ */
+/* $OpenBSD: version.h,v 1.101 2024/03/11 04:59:47 djm Exp $ */
 
-#define SSH_VERSION	"OpenSSH_9.6"
+#define SSH_VERSION	"OpenSSH_9.7"
 
 #define SSH_PORTABLE	"p1"
 #define SSH_HPN         "-hpn18.3.1"

--- a/xmss_hash.c
+++ b/xmss_hash.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: xmss_hash.c,v 1.3 2022/04/20 16:00:25 millert Exp $ */
+/* $OpenBSD: xmss_hash.c,v 1.4 2023/12/20 00:06:25 jsg Exp $ */
 /*
 hash.c version 20160722
 Andreas Hülsing
@@ -74,7 +74,7 @@ int prf(unsigned char *out, const unsigned char *in, const unsigned char *key, u
 }
 
 /*
- * Implemts H_msg
+ * Implements H_msg
  */
 int h_msg(unsigned char *out, const unsigned char *in, unsigned long long inlen, const unsigned char *key, const unsigned int keylen, const unsigned int n)
 {


### PR DESCRIPTION
This PR includes pulling in the OpenSSH 9.7 changes as well as updating binn.[c|h] to the most recent versions. As a note, binn is no longer c89 compatible because of the use of the always_inline attribute. As such, I've removed the c89 compatibility test from the CI tests. Additionally, I had to make minor changes to putty-ciphers.sh and Makefile in regress.

Additionally, there is a staging commit where I committed after the first merge but didn't resolve any of the conflicts. This is to create a method to show precisely what changes had to be made to resolve the conflicts. 

Passes all CI tests and functionality tests. 