### PR TITLE
cipher: Restore DisableMTAES capability to resolve FIPS SIGSEGV.

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -172,6 +172,7 @@ typedef enum {
 	oLocalCommand, oPermitLocalCommand, oRemoteCommand,
 	oTcpRcvBufPoll, oHPNDisabled,
 	oNoneEnabled, oNoneMacEnabled, oNoneSwitch,
+	oDisableMTAES,
 	oMetrics, oMetricsPath, oMetricsInterval, oFallback, oFallbackPort,
 	oVisualHostKey,
 	oKexAlgorithms, oIPQoS, oRequestTTY, oSessionType, oStdinNull,
@@ -310,6 +311,7 @@ static struct {
 	{ "noneenabled", oNoneEnabled },
 	{ "nonemacenabled", oNoneMacEnabled },
 	{ "noneswitch", oNoneSwitch },
+	{ "disablemtaes", oDisableMTAES },
 	{ "metrics", oMetrics },
 	{ "metricspath", oMetricsPath },
 	{ "metricsinterval", oMetricsInterval },
@@ -1267,6 +1269,10 @@ parse_time:
 
 	case oNoneMacEnabled:
 		intptr = &options->nonemac_enabled;
+		goto parse_flag;
+
+	case oDisableMTAES:
+		intptr = &options->disable_multithreaded;
 		goto parse_flag;
 
 	case oMetrics:
@@ -2692,6 +2698,7 @@ initialize_options(Options * options)
 	options->none_switch = -1;
 	options->none_enabled = -1;
 	options->nonemac_enabled = -1;
+	options->disable_multithreaded = -1;
 	options->metrics = -1;
 	options->metrics_path = NULL;
 	options->metrics_interval = -1;
@@ -2891,6 +2898,8 @@ fill_default_options(Options * options)
 		fprintf(stderr, "None MAC can only be used with the None cipher. None MAC disabled.\n");
 		options->nonemac_enabled = 0;
 	}
+	if (options->disable_multithreaded == -1)
+		options->disable_multithreaded = 0;
 	if (options->metrics == -1)
 		options->metrics = 0;
 	if (options->metrics_interval == -1)

--- a/readconf.h
+++ b/readconf.h
@@ -125,6 +125,7 @@ typedef struct {
 	int     none_switch;    /* Use none cipher */
 	int     none_enabled;   /* Allow none to be used */
 	int     nonemac_enabled;   /* Allow none to be used */
+	int     disable_multithreaded; /* Disable multithreaded aes-ctr */
         int     metrics; /* enable metrics */
         int     metrics_interval; /* time in seconds between polls */
         char   *metrics_path; /* path for the metrics files */

--- a/servconf.c
+++ b/servconf.c
@@ -192,6 +192,7 @@ initialize_server_options(ServerOptions *options)
 	options->hpn_disabled = -1;
 	options->none_enabled = -1;
 	options->nonemac_enabled = -1;
+	options->disable_multithreaded = -1;
 	options->ip_qos_interactive = -1;
 	options->ip_qos_bulk = -1;
 	options->version_addendum = NULL;
@@ -438,6 +439,8 @@ fill_default_server_options(ServerOptions *options)
 		debug ("Attempted to enabled None MAC without setting None Enabled to true. None MAC disabled.");
 		options->nonemac_enabled = 0;
 	}
+	if (options->disable_multithreaded == -1)
+		options->disable_multithreaded = 0;
 	if (options->hpn_disabled == -1)
 		options->hpn_disabled = 0;
 	if (options->ip_qos_interactive == -1)
@@ -522,6 +525,7 @@ typedef enum {
 	sKbdInteractiveAuthentication, sListenAddress, sAddressFamily,
 	sPrintMotd, sPrintLastLog, sIgnoreRhosts,
 	sNoneEnabled, sNoneMacEnabled, sTcpRcvBufPoll, sHPNDisabled,
+	sDisableMTAES,
 	sX11Forwarding, sX11DisplayOffset, sX11UseLocalhost,
 	sPermitTTY, sStrictModes, sEmptyPasswd, sTCPKeepAlive,
 	sPermitUserEnvironment, sAllowTcpForwarding, sCompression,
@@ -692,6 +696,7 @@ static struct {
 	{ "tcprcvbufpoll", sTcpRcvBufPoll, SSHCFG_ALL },
 	{ "noneenabled", sNoneEnabled, SSHCFG_ALL },
 	{ "nonemacenabled", sNoneMacEnabled, SSHCFG_ALL },
+	{ "disableMTAES", sDisableMTAES, SSHCFG_ALL },
 	{ "kexalgorithms", sKexAlgorithms, SSHCFG_GLOBAL },
 	{ "include", sInclude, SSHCFG_ALL },
 	{ "ipqos", sIPQoS, SSHCFG_ALL },
@@ -1571,6 +1576,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		intptr = &options->nonemac_enabled;
 		goto parse_flag;
 		
+	case sDisableMTAES:
+		intptr = &options->disable_multithreaded;
+		goto parse_flag;
+
 	case sHostbasedAuthentication:
 		intptr = &options->hostbased_authentication;
 		goto parse_flag;

--- a/servconf.h
+++ b/servconf.h
@@ -202,6 +202,7 @@ typedef struct {
 	int	hpn_disabled;		/* disable hpn functionality. false by default */
 	int	none_enabled;		/* Enable NONE cipher switch */
 	int     nonemac_enabled;        /* Enable NONE MAC switch */
+	int disable_multithreaded; /* Disable multithreaded aes-ctr cipher */
   
 	int	permit_tun;
 

--- a/session.c
+++ b/session.c
@@ -547,7 +547,8 @@ do_exec_no_pty(struct ssh *ssh, Session *s, const char *command)
 	    s->is_subsystem, 0);
 #endif
 	/* switch to the parallel ciphers if necessary */
-	cipher_switch(ssh);
+	if (options.disable_multithreaded == 0)
+		cipher_switch(ssh);
 	return 0;
 }
 
@@ -651,7 +652,8 @@ do_exec_pty(struct ssh *ssh, Session *s, const char *command)
 	    options.ip_qos_interactive, options.ip_qos_bulk);
 	session_set_fds(ssh, s, ptyfd, fdout, -1, 1, 1);
 	/* switch to the parallel cipher if appropriate */
-	cipher_switch(ssh);
+	if (options.disable_multithreaded == 0)
+		cipher_switch(ssh);
 	return 0;
 }
 

--- a/ssh.c
+++ b/ssh.c
@@ -1887,7 +1887,8 @@ fork_postauth(struct ssh *ssh)
 		error_f("stdfd_devnull failed");
 	/* we do the cipher switch here in the event that the client
 	   is forking or has a delayed fork */
-	cipher_switch(ssh);
+	if (options.disable_multithreaded == 0)
+		cipher_switch(ssh);
 }
 
 static void
@@ -2365,7 +2366,8 @@ ssh_session2(struct ssh *ssh, const struct ssh_conn_info *cinfo)
 		 * one of our parallel versions. If the client is
 		 * forking then we handle it in fork_postauth()
 		 */
-		cipher_switch(ssh);
+		if (options.disable_multithreaded == 0)
+			cipher_switch(ssh);
 	}
 	return client_loop(ssh, tty_flag, tty_flag ?
 	    options.escape_char : SSH_ESCAPECHAR_NONE, id);


### PR DESCRIPTION
This restores the functionality provided in 9ed8887c95b1a892b988c3dd30f1f5e7e48e0b56 and 4a535c4ac4d871a13798340b32f838f6fd346ddd, but was then removed in the 9.2 -> 9.3 rebase process, as I mentioned [in the FIPS bug thread](https://github.com/rapier1/hpn-ssh/issues/36#issuecomment-2197784259). In my preliminary testing, this patch allows our FIPS servers to talk to each other happily, so long as both sides of the conversation use `DisableMTAES=yes`. We (ServiceNow) will do some more testing on this as we can, but I'm submitting this upstream for the greater benefit, and hopefully to get some more-qualified-than-my-own eyes on this :)