### PR TITLE
Linking failure on big endian (s390x)

### DIFF
--- a/umac.c
+++ b/umac.c
@@ -154,7 +154,7 @@ u_int32_t umac_get_u32_le(const void *vp)
         return (v);
 }
 
-#if (! __LITTLE_ENDIAN__) /* compile time warning thrown otherwise */
+#if 0 /* compile time warning thrown otherwise */
 static __attribute__((__bounded__(__minbytes__, 1, 4)));
 void umac_put_u32_le(void *vp, u_int32_t v)
 {


### PR DESCRIPTION
/usr/bin/ld: umac128.o (symbol from plugin): in function `umac_put_u32_le':
(.text+0x0): multiple definition of `umac_put_u32_le'; umac.o (symbol from plugin):(.text+0x0): first defined here
collect2: error: ld returned 1 exit status

This function (umac_put_u32_le) has been enclosed in a

    #if (! __LITTLE_ENDIAN__) /* compile time warning thrown otherwise */

block in order to fix this issue for little endian architectures. Since the function is not used on big endian architectures either, this can be fixed by changing the above to

    #if 0 /* compile time warning thrown otherwise */