### PR TITLE
Fix issue with pam where it was looking for an sshd pam file instead hpnsshd

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -71,7 +71,7 @@
 #include "sshbuf.h"
 
 #if !defined(SSHD_PAM_SERVICE)
-# define SSHD_PAM_SERVICE		"sshd"
+# define SSHD_PAM_SERVICE		"hpnsshd"
 #endif
 
 static void add_listen_addr(ServerOptions *, const char *,


### PR DESCRIPTION
Fix issue with pam where it was looking for an sshd pam file instead of hpnsshd.

Mitch found this. Seems to have been cause by a change in OpenSSH 9.8 where they made the pam service configurable and made the default sshd. This will work in most situations because OpenSSH is already installed but will fail if the only installed ssh server is hpn-ssh. This fix simply changes the default name from 'sshd' to 'hpnsshd'.