### PR TITLE
Fixes sftp path in sshd_config when reconfiguring.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -269,7 +269,7 @@ $(MANPAGES): $(MANPAGES_IN)
 		$(FIXPATHSCMD) $${manpage} | $(FIXALGORITHMSCMD) > $@; \
 	fi
 
-$(CONFIGFILES): $(CONFIGFILES_IN)
+$(CONFIGFILES): $(CONFIGFILES_IN) Makefile
 	conffile=`echo $@ | sed 's/.out$$//'`; \
 	$(FIXPATHSCMD) $(srcdir)/$${conffile} > $@
 


### PR DESCRIPTION
In some situation the path to the SFTP subsystem in sshd_config can be configured incorrectly by the build process.

For example, if you do the following:

./configure
make
./configure --prefix=/opt/ssh
make
sudo make install

The installed sshd_config file will have

Subsystem sftp  /usr/libexec/sftp-server

instead of

Subsystem sftp  /opt/ssh/libexec/sftp-server

This fix resolves the problem by including the Makefile in the config files.