### PR TITLE
MPTCP: use it by default on the server side

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2644,38 +2644,6 @@ if test ! -z "$check_for_openpty_ctty_bug"; then
 fi
 
 
-# Testing MPTCP Support
-# Does the OS support MPTCP?
-# We don't use this at the moment
-# but I am holding it in resrve -cjr 04/04/2025
-	AC_MSG_CHECKING([whether the OS supports MPTCP])
-	AC_RUN_IFELSE(
-		[AC_LANG_PROGRAM([[
-		#include <stdio.h>
-		#include <stdlib.h>
-		#include <unistd.h>
-		#include <sys/types.h>
-		#include <sys/socket.h>
-		#include <stdbool.h>
-		#include <netinet/in.h>
-
-		]], [[
-		int sock = -1;
-		sock = socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP);
-		if (sock < 0) {
-		   exit(1);
-		   }
-		]])],
-		[
-			AC_MSG_RESULT([yes])
-			AC_DEFINE([HAVE_MPTCP], [1],
-			    [OS Supports MPTCP])
-		],
-		[
-			AC_MSG_RESULT([no])
-		]
-	)
-
 if test "x$ac_cv_func_getaddrinfo" = "xyes" && \
     test "x$check_for_hpux_broken_getaddrinfo" = "x1"; then
 	AC_MSG_CHECKING([if getaddrinfo seems to work])

--- a/defines.h
+++ b/defines.h
@@ -941,10 +941,6 @@ struct winsize {
 # define SSH_IOBUFSZ (32*1024)
 #endif
 
-#ifndef IPPROTO_MPTCP
-#define IPPROTO_MPTCP 262
-#endif
-
 /*
  * We want functions in openbsd-compat, if enabled, to override system ones.
  * We no-op out the weak symbol definition rather than remove it to reduce

--- a/hpnsshd_config.5
+++ b/hpnsshd_config.5
@@ -2067,7 +2067,8 @@ directives.
 .It Cm UseMPTCP
 If set to
 .Cm yes ,
-this will enable Multipath TCP (MPTCP) instead of TCP (this only works on Linux).
+this will enable Multipath TCP (MPTCP) support. This only works on Linux. MPTCP
+will be used if requested by clients. If not, TCP will be used as before.
 The default is
 .Cm no .
 .It Cm UsePAM

--- a/hpnsshd_config.5
+++ b/hpnsshd_config.5
@@ -2070,7 +2070,7 @@ If set to
 this will enable Multipath TCP (MPTCP) support. This only works on Linux. MPTCP
 will be used if requested by clients. If not, TCP will be used as before.
 The default is
-.Cm no .
+.Cm yes .
 .It Cm UsePAM
 Enables the Pluggable Authentication Module interface.
 If set to

--- a/servconf.c
+++ b/servconf.c
@@ -487,7 +487,7 @@ fill_default_server_options(ServerOptions *options)
 	if (options->hpn_disabled == -1)
 		options->hpn_disabled = 0;
 	if (options->use_mptcp == -1)
-		options->use_mptcp = 0;
+		options->use_mptcp = 1;
 	if (options->ip_qos_interactive == -1)
 		options->ip_qos_interactive = IPTOS_DSCP_EF;
 	if (options->ip_qos_bulk == -1)

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -355,7 +355,11 @@ ssh_create_socket(struct addrinfo *ai)
 
 	/* user request for Multipath TCP */
 	if (options.use_mptcp)
+#ifdef IPPROTO_MPTCP
 		sock = socket(ai->ai_family, ai->ai_socktype, IPPROTO_MPTCP);
+#else
+		sock = -1;
+#endif
 	else
 		sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 

--- a/sshd.c
+++ b/sshd.c
@@ -828,8 +828,12 @@ listen_on_addrs(struct listenaddr *la)
 		}
 		/* Create socket for listening. */
 		if (options.use_mptcp)
+#ifdef IPPROTO_MPTCP
 			listen_sock = socket(ai->ai_family, ai->ai_socktype,
 			    IPPROTO_MPTCP);
+#else
+			listen_sock = -1;
+#endif
 		else
 			listen_sock = socket(ai->ai_family, ai->ai_socktype,
 			    ai->ai_protocol);

--- a/sshd.c
+++ b/sshd.c
@@ -827,14 +827,15 @@ listen_on_addrs(struct listenaddr *la)
 			continue;
 		}
 		/* Create socket for listening. */
-		if (options.use_mptcp)
+		listen_sock = -1;
 #ifdef IPPROTO_MPTCP
+		if (options.use_mptcp)
 			listen_sock = socket(ai->ai_family, ai->ai_socktype,
 			    IPPROTO_MPTCP);
-#else
-			listen_sock = -1;
 #endif
-		else
+
+		/* Fallback to "plain" TCP if MPTCP is not available */
+		if (listen_sock == -1)
 			listen_sock = socket(ai->ai_family, ai->ai_socktype,
 			    ai->ai_protocol);
 

--- a/sshd_config
+++ b/sshd_config
@@ -103,7 +103,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #PermitTunnel no
 #ChrootDirectory none
 #VersionAddendum none
-#UseMPTCP no
+#UseMPTCP yes
 
 # no default banner path
 #Banner none


### PR DESCRIPTION
Hello,

Here are some small modifications to enable MPTCP support on the server side by default, if supported. If not, TCP is used like before.

MPTCP in OpenSSH is currently only supported on Linux. On Linux, an MPTCP socket support "plain" TCP and MPTCP requests. In case of "plain" TCP request, a "plain" TCP socket is returned to the application at the `accept()` time: no performance impact compared to before. With this in place, clients can decide if MPTCP is used or not: typically clients benefit the most on MPTCP, and know if it is interesting to use it or not.

Note that this is also what GO applications are doing: since [GO v1.24](https://go.dev/doc/go1.24#netpkgnet), all listening sockets have MPTCP support by default (if supported).